### PR TITLE
Python 2-Body Propagator (no unit tests)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ fortranformat
 plotly
 pyyaml
 openorb
+numba
 pytest
 pytest-cov
 coveralls

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -10,6 +10,7 @@ fortranformat
 plotly
 pyyaml
 openorb
+numba
 pytest
 pytest-cov<2.6.0
 coveralls

--- a/thor/orbits/propagate/__init__.py
+++ b/thor/orbits/propagate/__init__.py
@@ -1,1 +1,2 @@
 from .stumpff import *
+from .universal import *

--- a/thor/orbits/propagate/__init__.py
+++ b/thor/orbits/propagate/__init__.py
@@ -1,0 +1,1 @@
+from .stumpff import *

--- a/thor/orbits/propagate/stumpff.py
+++ b/thor/orbits/propagate/stumpff.py
@@ -5,7 +5,7 @@ __all__ = [
     "calcC2C3"
 ]
 
-@jit(nopython=True)
+@jit("UniTuple(f8, 2)(f8)", nopython=True)
 def calcC2C3(psi):
     """
     Calculate the second and third Stumpff functions. 

--- a/thor/orbits/propagate/stumpff.py
+++ b/thor/orbits/propagate/stumpff.py
@@ -1,0 +1,50 @@
+import numpy as np
+from numba import jit
+
+__all__ = [
+    "calcC2C3"
+]
+
+@jit(nopython=True)
+def calcC2C3(psi):
+    """
+    Calculate the second and third Stumpff functions. 
+    
+    .. math::
+        
+        c_2(\Psi) = \begin{cases}
+            \frac{1 - \cos{\sqrt{\Psi}}}{\Psi} & \text{ if } \Psi > 0 \\ 
+            \frac{1 - \cosh{\sqrt{-\Psi}}}{\Psi} & \text{ if } \Psi < 0 \\ 
+            \frac{1}{2} & \text{ if } \Psi= 0
+        \end{cases}
+        
+        c_3(\Psi) = \begin{cases}
+            \frac{\sqrt{\Psi} - \sin{\sqrt{\Psi}}}{\sqrt{\Psi^3}} & \text{ if } \Psi > 0 \\ 
+            \frac{\sinh{\sqrt{-\Psi}} - \sqrt{-\Psi}}{\sqrt{(-\Psi)^3}} & \text{ if } \Psi < 0 \\ 
+            \frac{1}{6} & \text{ if } \Psi= 0
+        \end{cases}
+        
+    For more details on theory see Chapter 2 in David A. Vallado's "Fundamentals of Astrodynamics
+    and Applications" or Chapter 3 in Howard Curtis' "Orbital Mechanics for Engineering Students".
+    
+    Parameters
+    ----------
+    psi : float
+        Dimensionless parameter at which to evaluate the Stumpff functions (equivalent to alpha * chi**2). 
+        
+    Returns
+    -------
+    c2, c3 : float, float
+        Second and third Stumpff functions.
+    """
+    if psi > 0.0:
+        c2 = (1 - np.cos(np.sqrt(psi))) / psi
+        c3 = (np.sqrt(psi) - np.sin(np.sqrt(psi))) / np.sqrt(psi)**3
+    elif psi < 0.0:
+        c2 = (np.cosh(np.sqrt(-psi)) - 1) / (-psi)
+        c3 = (np.sinh(np.sqrt(-psi)) - np.sqrt(-psi)) / np.sqrt(-psi)**3
+    else:
+        c2 = 1/2.
+        c3 = 1/6.
+    
+    return c2, c3

--- a/thor/orbits/propagate/universal.py
+++ b/thor/orbits/propagate/universal.py
@@ -1,0 +1,72 @@
+import numpy as np
+from numba import jit
+from astropy import constants as c
+from astropy import units as u
+
+from .stumpff import calcC2C3
+
+__all__ = [
+    "calcChi"
+]
+
+MU = (c.G * c.M_sun).to(u.AU**3 / u.day**2).value
+
+@jit("f8(f8[:], f8[:], f8, f8, i8, f8)", nopython=True)
+def calcChi(r, v, dt, mu=MU, maxIterations=10000, tol=1e-14):
+    """
+    Calculate universal anomaly chi using Newton-Raphson. 
+    
+    Parameters
+    ----------
+    r : `~numpy.ndarray` (3)
+        Heliocentric position vector in units of AU. [J2000 ECLIPTIC]
+    v : `~numpy.ndarray` (3)
+        Heliocentric velocity vector in units of AU per day. [J2000 ECLIPTIC]
+    dt : float
+        Time from epoch to which calculate chi in units of decimal days.
+    mu : float, optional
+        Gravitational parameter (GM) of the attracting body in units of 
+        AU**3 / d**2. 
+    iterations : int, optional
+        Maximum number of iterations over which to converge. If number of iterations is 
+        exceeded, will return the value of the universal anomaly at the last iteration. 
+    tol : float, optional
+        Numerical tolerance to which to compute chi using the Newtown-Raphson 
+        method. 
+    
+    Returns
+    -------
+    chi : float
+        Universal anomaly. 
+    """
+    v_mag = np.linalg.norm(v)
+    r_mag = np.linalg.norm(r)
+    rv_mag = np.dot(r, v) / r_mag
+    sqrt_mu = np.sqrt(mu)
+    
+    alpha = -v_mag**2 / mu + 2 / r_mag
+    chi = np.sqrt(mu) * np.abs(alpha) * dt
+    ratio = 1e10
+    
+    iterations = 0
+    while np.abs(ratio) > tol:
+        chi2 = chi**2
+        psi = alpha * chi2
+        c2, c3 = calcC2C3(psi)
+        
+        # Newton-Raphson
+        f = (r_mag * rv_mag / sqrt_mu * chi2 * c2 
+             + (1 - alpha*r_mag) * chi**3 * c3
+             + r_mag * chi 
+             - sqrt_mu * dt)
+        fp = (r_mag * rv_mag / sqrt_mu * chi * (1 - alpha * chi2 * c3) 
+              + (1 - alpha * r_mag) * chi2 * c2
+              + r_mag)
+        
+        ratio = f / fp
+        chi -= ratio
+        iterations += 1
+        if iterations >= maxIterations:
+            break
+        
+    return chi


### PR DESCRIPTION
Adds a python two-body propagator which uses the universal anomaly formalism.

I'll create a separate issue to add unit tests to this part of the code. 

A future stretch goal would be to add a second propagator that uses the original Kepler-Laplace-Gauss formalism but this will do for now. 