### PR TITLE
Auto shutdown fixes

### DIFF
--- a/infra/workers/configure_worker.sh
+++ b/infra/workers/configure_worker.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
-set -euo pipefail
+echo "running configure_worker.sh"
+
+set -xeo pipefail
 
 # Check out the requested git version
+echo "checking out $THOR_GIT_REF"
 cd /opt/thor
 git fetch
+git fetch fork
 git checkout $THOR_GIT_REF
 
 # Update dependencies, if requested
 if [ "${UPDATE_DEPS}" = "true" ]; then
+    echo "updating dependencies"
     /opt/miniconda3/bin/conda run -n thor_py38 --live-stream pip install -e .
 fi
 
 # Update thor queue setting
+echo "setting thor queue"
 sed -i "s/THOR_QUEUE=.*/THOR_QUEUE=${THOR_QUEUE}/g" /etc/thor/env
 
 # Enable THOR on system boot
-systemctl enable thor-worker
+echo "enabling THOR on boot"
+systemctl enable thor-worker.service

--- a/infra/workers/image.pkr.hcl
+++ b/infra/workers/image.pkr.hcl
@@ -47,6 +47,6 @@ build {
     ]
     # Execute command with sudo
     execute_command = "chmod +x {{ .Path }}; sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    script = "configure_worker.sh"
+    script = "./configure_worker.sh"
   }
 }

--- a/infra/workers/setup_base_image.sh
+++ b/infra/workers/setup_base_image.sh
@@ -4,7 +4,7 @@
 ## Setup script for building a disk image for the taskqueue worker.
 ##
 
-set -eo pipefail
+set -xeo pipefail
 
 ## Install system dependencies
 add-apt-repository universe  # Required to install jq in Ubuntu 18.04.1

--- a/infra/workers/thor-worker.service
+++ b/infra/workers/thor-worker.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+Restart=always
 WorkingDirectory=/opt/thor
 EnvironmentFile=/etc/thor/env
 ExecStart=/etc/thor/start_worker.sh

--- a/thor/taskqueue/client.py
+++ b/thor/taskqueue/client.py
@@ -300,7 +300,7 @@ class Worker:
                 if 0 <= idle_shutdown_timeout < since_last_task:
                     logger.info("idle shutdown timeout has elapsed")
                     self.terminate()
-                    return
+                    break
 
                 time.sleep(poll_interval)
             else:

--- a/thor/taskqueue/compute_engine.py
+++ b/thor/taskqueue/compute_engine.py
@@ -50,10 +50,10 @@ def _google_metadata_request(path: str) -> Any:
         )
         if response.status_code == 503:
             # Indicates metadata server maintenance. Retry.
-            time.sleep(1)
             retry_count += 1
-        else:
-            break
+            time.sleep(1)
+            continue
+        break
     response.raise_for_status()
     return response.content
 
@@ -75,7 +75,7 @@ def discover_running_on_compute_engine() -> bool:
         return False
 
 
-def discover_instance_name() -> bytes:
+def discover_instance_name() -> str:
     """
     Query Google Compute Engine metadata to discover the host instance's name.
 
@@ -90,12 +90,12 @@ def discover_instance_name() -> bytes:
     --------
 
     >>> discover_instance_name()
-    b'asgard'
+    'asgard'
     """
-    return _google_metadata_request("/computeMetadata/v1/instance/name")
+    return _google_metadata_request("/computeMetadata/v1/instance/name").decode()
 
 
-def discover_instance_zone() -> bytes:
+def discover_instance_zone() -> str:
     """
     Query Google Compute Engine metadata to discover the host instance's zone.
 
@@ -111,13 +111,13 @@ def discover_instance_zone() -> bytes:
     --------
 
     >>> discover_instance_zone()
-    b'projects/492788363398/zones/us-west1-a'
+    'projects/492788363398/zones/us-west1-a'
     """
-    return _google_metadata_request("/computeMetadata/v1/instance/zone")
+    return _google_metadata_request("/computeMetadata/v1/instance/zone").decode()
 
 
-def discover_project_id() -> bytes:
-    return _google_metadata_request("/computeMetadata/v1/project/project-id")
+def discover_project_id() -> str:
+    return _google_metadata_request("/computeMetadata/v1/project/project-id").decode()
 
 
 def _get_access_token() -> str:

--- a/thor/taskqueue/compute_engine.py
+++ b/thor/taskqueue/compute_engine.py
@@ -31,12 +31,12 @@ def terminate_self():
     compute_client = googleapiclient.discovery.build("compute", "v1")
     operation = compute_client.instances().delete(
         project=project, zone=zone, instance=name,
-    )
+    ).execute()
 
     logger.info("Blocking to wait for the delete to complete")
     compute_client.zoneOperations().wait(
         project=project, zone=zone, operation=operation["name"]
-    )
+    ).execute()
 
 
 def _google_metadata_request(path: str) -> Any:

--- a/thor/taskqueue/compute_engine.py
+++ b/thor/taskqueue/compute_engine.py
@@ -43,7 +43,11 @@ def _google_metadata_request(path: str) -> Any:
     retry_limit = 30
     retry_count = 0
     while retry_count < retry_limit:
-        response = requests.get("http://metadata.google.internal" + path, timeout=1.0)
+        response = requests.get(
+            "http://metadata.google.internal" + path,
+            headers={"Metadata-Flavor": "Google"},
+            timeout=1.0,
+        )
         if response.status_code == 503:
             # Indicates metadata server maintenance. Retry.
             time.sleep(1)

--- a/thor/taskqueue/compute_engine.py
+++ b/thor/taskqueue/compute_engine.py
@@ -46,9 +46,10 @@ def _google_metadata_request(path: str) -> Any:
         response = requests.get("http://metadata.google.internal" + path, timeout=1.0)
         if response.status_code == 503:
             # Indicates metadata server maintenance. Retry.
-            retry_count += 1
             time.sleep(1)
-            continue
+            retry_count += 1
+        else:
+            break
     response.raise_for_status()
     return response.content
 


### PR DESCRIPTION
This fixes numerous bugs in #68, mostly around fetching Google Compute Engine Metadata.

1. We had an infinite loop when fetching metadata.
2. Even without the infinite loop, we need to pass a particular header when making Metadata requests, or the request gets denied.
3. Even with the header, we need to decode the raw bytes into a Python string for any metadata response.
4. Even when all metadata has been fetched, we need to actually "execute" the `DELETE instance` API call.