### PR TITLE
Announce when tasks have completed to a PubSub topic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ setuptools>=45
 wheel
 setuptools_scm>=6.0
 pika
-google-cloud-storage
+google-cloud-storage>=1.39.0
 google-cloud-pubsub
 google-cloud-core==1.3.0
 google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ wheel
 setuptools_scm>=6.0
 pika
 google-cloud-storage
+google-cloud-pubsub
 google-cloud-core==1.3.0
 google-api-python-client
 colorama

--- a/runTHORWorker.py
+++ b/runTHORWorker.py
@@ -3,6 +3,7 @@ import os
 
 import pika
 from google.cloud.storage.client import Client as GCSClient
+from google.cloud.pubsub.client import Client as PubsubClient
 
 
 def parse_args():
@@ -76,7 +77,8 @@ def main():
     )
     queue.connect()
     gcs = GCSClient()
-    worker = Worker(gcs, queue)
+    pubsub = PubsubClient()
+    worker = Worker(gcs, pubsub, queue)
     worker.run_worker_loop(args.poll_interval, args.idle_shutdown_timeout)
 
 

--- a/runTHORWorker.py
+++ b/runTHORWorker.py
@@ -3,7 +3,7 @@ import os
 
 import pika
 from google.cloud.storage.client import Client as GCSClient
-from google.cloud.pubsub.client import Client as PubsubClient
+from google.cloud.pubsub_v1 import PublisherClient as PubsubClient
 
 
 def parse_args():

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     plotly
     ipykernel
     pika
-    google-cloud-storage
+    google-cloud-storage>=1.39.0
     google-cloud-pubsub
     google-cloud-core==1.3.0
     google-api-python-client

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     ipykernel
     pika
     google-cloud-storage
+    google-cloud-pubsub
     google-cloud-core==1.3.0
     google-api-python-client
     colorama

--- a/submitTHORJob.py
+++ b/submitTHORJob.py
@@ -141,7 +141,7 @@ def main():
     if args.pubsub_topic is not None:
         # Validate pubsub topic
         split_topic = args.pubsub_topic.split("/")
-        if len(split_topic) != 4 or split_topic[0] != "projects" or split_topic[2] != "projects":
+        if len(split_topic) != 4 or split_topic[0] != "projects" or split_topic[2] != "topics":
             raise ValueError(
                 "--pubsub-topic must match pattern 'projects/{project}/topics/{topic}'"
             )

--- a/submitTHORJob.py
+++ b/submitTHORJob.py
@@ -159,7 +159,7 @@ def main():
     manifest = taskqueue_client.launch_job(
         config=config,
         observations=preprocessed_observations,
-        orbits=test_orbits
+        orbits=test_orbits,
         job_completion_pubsub_topic=args.pubsub_topic,
     )
     taskqueue_client.monitor_job_status(manifest.job_id)

--- a/thor/taskqueue/jobs.py
+++ b/thor/taskqueue/jobs.py
@@ -1,12 +1,19 @@
-from typing import AnyStr, List, Mapping
+from typing import AnyStr, List, Mapping, Optional
 
 import datetime
 import json
+import logging
+import re
 
 from google.cloud.storage import Bucket
+import google.api_core.exceptions
+from google.cloud.pubsub_v1 import PublisherClient
+import google.cloud.pubsub
 
 from thor.orbits import Orbits
 from thor.taskqueue.tasks import Task
+
+logger = logging.getLogger("thor")
 
 
 class JobManifest:
@@ -20,6 +27,8 @@ class JobManifest:
     ----------
     creation_time : datetime.datetime
         The time that this JobManifest was created, including time zone.
+    update_time : datetime.datetime
+        The most recent time that this JobManifest was modified, including time zone.
     job_id : str
         A string identifier for the job.
     task_ids : List[str]
@@ -27,14 +36,24 @@ class JobManifest:
     orbit_ids : List[str]
         A list of string IDs of orbits associated with the job's tasks. Each
         Task is assigned a single Orbit.
+    incomplete_tasks : List[str]
+        A list of the IDs of tasks that have not completed for this job.
+    pubsub_topic : Optional[str]
+        The name of a pubsub topic to publish to when all tasks in the Job are
+        done. Note that pubsub topic names look like URL paths, and include a
+        project name; they follow the pattern
+        projects/{project-id}/topic/{topic}.
     """
 
     def __init__(
         self,
         creation_time: datetime.datetime,
+        update_time: datetime.datetime,
         job_id: str,
         orbit_ids: List[str],
         task_ids: List[str],
+        incomplete_tasks: List[str],
+        pubsub_topic: Optional[str] = None,
     ):
         """
         Low-level constructor for a JobManifest.
@@ -42,12 +61,25 @@ class JobManifest:
         Use the create classmethod instead.
         """
         self.creation_time = creation_time
+        self.update_time = update_time
         self.job_id = job_id
         self.orbit_ids = orbit_ids
         self.task_ids = task_ids
+        self.incomplete_tasks = incomplete_tasks
+
+        if pubsub_topic is not None:
+            topic_parts = pubsub_topic.split("/")
+            if len(topic_parts) != 4 or topic_parts[0] != "projects" or topic_parts[2] != "topics":
+                raise ValueError(
+                    "pubsub topic must match pattern 'projects/{project}/topics/{topic}'"
+                )
+            self.pubsub_topic = pubsub_topic
+        else:
+            self.pubsub_topic = None
+
 
     @classmethod
-    def create(cls, job_id: str) -> "JobManifest":
+    def create(cls, job_id: str, pubsub_topic: Optional[str] = None) -> "JobManifest":
         """
         Create a new empty JobManifest with the given job ID.
 
@@ -55,6 +87,10 @@ class JobManifest:
         ----------
         job_id : str
             Identifier for the job.
+        job_completion_pubsub_topic : Optional[str]
+            The name of a pubsub topic (in the canonical
+            projects/{project}/topics/{topic} format) which should get an
+            announcement when a launched job completed.
 
         Returns
         -------
@@ -62,7 +98,15 @@ class JobManifest:
             The newly created JobManifest.
         """
         now = datetime.datetime.now(datetime.timezone.utc)
-        return JobManifest(creation_time=now, job_id=job_id, orbit_ids=[], task_ids=[])
+        return JobManifest(
+            creation_time=now,
+            update_time=now,
+            job_id=job_id,
+            orbit_ids=[],
+            task_ids=[],
+            incomplete_tasks=[],
+            pubsub_topic=pubsub_topic,
+        )
 
     def append(self, orbit: Orbits, task: Task):
         """Add an Orbit and Task to the Manifest.
@@ -78,6 +122,7 @@ class JobManifest:
         assert len(orbit) == 1, "There should be exactly one Orbit per task."
         self.orbit_ids.append(orbit.ids[0])
         self.task_ids.append(task.task_id)
+        self.incomplete_tasks.append(task.task_id)
 
     def to_str(self) -> str:
         """Serialize the JobManifest as a string.
@@ -88,14 +133,17 @@ class JobManifest:
             JSON serialization of the JobManifest.
         """
 
-        return json.dumps(
-            {
-                "job_id": self.job_id,
-                "creation_time": self.creation_time.isoformat(),
-                "orbit_ids": self.orbit_ids,
-                "task_ids": self.task_ids,
-            }
-        )
+        data = {
+            "job_id": self.job_id,
+            "creation_time": self.creation_time.isoformat(),
+            "update_time": self.update_time.isoformat(),
+            "orbit_ids": self.orbit_ids,
+            "task_ids": self.task_ids,
+            "incomplete_tasks": self.incomplete_tasks,
+        }
+        if self.pubsub_topic is not None:
+            data["pubsub_topic"] = self.pubsub_topic
+        return json.dumps(data)
 
     @classmethod
     def from_str(cls, data: AnyStr) -> "JobManifest":
@@ -117,6 +165,7 @@ class JobManifest:
         as_dict["creation_time"] = datetime.datetime.fromisoformat(
             as_dict["creation_time"]
         )
+        as_dict["update_time"] = datetime.datetime.fromisoformat(as_dict["update_time"])
         return cls(**as_dict)
 
 
@@ -134,6 +183,54 @@ def upload_job_manifest(bucket: Bucket, manifest: JobManifest):
     """
     path = f"thor_jobs/v1/job-{manifest.job_id}/manifest.json"
     bucket.blob(path).upload_from_string(manifest.to_str())
+
+
+def mark_task_done_in_manifest(
+    bucket: Bucket, job_id: str, task_id: str
+) -> JobManifest:
+    """
+    """
+    path = f"thor_jobs/v1/job-{job_id}/manifest.json"
+
+    i = 0
+    max_retries = 32
+    while i < max_retries:
+        i += 1
+        try:
+            # Download the old version. Note the generation.
+            old_manifest_blob = bucket.blob(path)
+            old_manifest_blob.reload()
+            generation = old_manifest_blob.generation
+            assert generation is not None
+
+            as_str = old_manifest_blob.download_as_string(
+                if_generation_match=generation,
+            )
+
+            manifest = JobManifest.from_str(as_str)
+
+            # Remove the task from the manifest.
+            manifest.incomplete_tasks.remove(task_id)
+            # Update the timestamp
+            manifest.update_time = datetime.datetime.now(datetime.timezone.utc)
+
+            # Update the new version - as long as the generation hasn't changed.
+            bucket.blob(path).upload_from_string(
+                manifest.to_str(), if_generation_match=generation,
+            )
+            logger.debug(f"updated manifest generation=%s", generation)
+            return manifest
+        except google.api_core.exceptions.PreconditionFailed:
+            # The generation changed out from under us. Try again.
+            logger.debug(
+                "lost a race to update manifest (tried generation=%s)", generation
+            )
+        except google.api_core.exceptions.NotFound:
+            # Sometimes this appears if we ask for a very recent generation
+            logger.debug(
+                "got a 404 when asking to update manifest (tried generation=%s)",
+                generation,
+            )
 
 
 def download_job_manifest(bucket: Bucket, job_id: str) -> JobManifest:
@@ -154,3 +251,13 @@ def download_job_manifest(bucket: Bucket, job_id: str) -> JobManifest:
     path = f"thor_jobs/v1/job-{job_id}/manifest.json"
     as_str = bucket.blob(path).download_as_string()
     return JobManifest.from_str(as_str)
+
+
+def announce_job_done(client: PublisherClient, manifest: JobManifest):
+    logger.info("announcing that job %s is complete", manifest.job_id)
+    if manifest.pubsub_topic is None:
+        logger.info("no pubsub topic set for job %s", manifest.job_id)
+        return
+    announcement = manifest.to_str().encode()
+    future = client.publish(manifest.pubsub_topic, announcement)
+    future.result()


### PR DESCRIPTION
### summary ###

The idea here is to allow job-submitters to specify a Google PubSub topic when launching a Job. When the last Task in a Job has been completed, a message will get published to that PubSub topic. This will help out with implementing an API frontend to THOR.

There are two general arcs of work in this PR.
1. Allow job submitters to specify a PubSub topic, and thread it through to workers.
2. Get workers to figure out whether they finished the *last* Task in a Job, or whether there are more to go, without direct coordination.

### changes ###

Add fields to JobManifests: 
- incomplete_tasks: a list of Task IDs of tasks that have not completed for the job. 
- pubsub_topic: An optional string name of a PubSub topic to publish to when all tasks for the job are done. 
- update_time: The most recent time the JobManifest was modified.

Add logic to thor.taskqueues.client.Worker to update the JobManifest for a task's job when a task is completed. The completed task is removed from JobManifest's 'incomplete_tasks' list.

This update risks races, so the function which updates a JobManifest uses optimistic locking based on the 'generation' of the JobManifest's blob in Cloud Storage.

When the incomplete_tasks has just one entry, and the Worker removes it, the Worker knows it must have been the last task worker, so it can announce the completion of the job. It publishes the JobManifest to the pubsub topic specified.

Moved the thor.taskqueues.tasks.Task.mark_success and .mark_failed methods into thor.taskqueues.client.Worker, since the Worker is a more active component while the Task represents simple data.

Add logic to thor.taskqueues.client.Client to provide a PubSub topic name when launching a job.

Add google-cloud-pubsub as a new dependency.

Add new arguments to submitTHORJob.py to allow setting the pubsub topic for a job.

Update the integration test in thor/tests/test_taskqueue to verify job completion announcements.