### PR TITLE
Normalize task output paths

### DIFF
--- a/thor/taskqueue/tasks.py
+++ b/thor/taskqueue/tasks.py
@@ -220,6 +220,8 @@ class Task:
                     relative_dir,
                     filename,
                 )
+                # Normalize any components like './' or '../'
+                blobpath = posixpath.normpath(blobpath)
                 logger.debug("uploading %s to %s", filepath, blobpath)
                 bucket.blob(blobpath).upload_from_filename(filepath)
 


### PR DESCRIPTION
When tasks write outputs to object storage, they generate a path for the key that will hold each output file.

Before this commit, that path could contain POSIX-style relative path components. For example, you could have a path like 'tasks/taskid/outputs/./recovered_orbit_members.csv'. This should be normalized - that is, the ./ component should be removed, resulting in 'tasks/taskid/outputs/recovered_orbit_members.csv'.