### PR TITLE
Upload taskqueue task error messages correctly

### DIFF
--- a/thor/taskqueue/tasks.py
+++ b/thor/taskqueue/tasks.py
@@ -227,17 +227,22 @@ class Task:
         self, bucket: Bucket, result_directory: str, exception: Exception
     ):
         output_blobdir = _task_output_path(self.job_id, self.task_id)
-        exception_string = traceback.format_exception(
+        exception_strings = traceback.format_exception(
             etype=type(exception),
             value=exception,
             tb=exception.__traceback__,
         )
+        if len(exception_strings) == 1:
+            exception_string = exception_strings[0]
+        else:
+            exception_string = "Multiple errors:\n"
+            for i, e in enumerate(exception_strings):
+                exception_string += f"begin-exception-{i}:\n{e}\nend-exception-{i}"
+
         blobpath = posixpath.join(output_blobdir, "error_message.txt")
         logger.error("uploading exception trace to %s", blobpath)
         bucket.blob(blobpath).upload_from_string(exception_string)
         self._upload_results(self.bucket, result_directory)
-
-        raise NotImplementedError()
 
 
 # Generated randomly:

--- a/thor/taskqueue/tests/test_tasks.py
+++ b/thor/taskqueue/tests/test_tasks.py
@@ -1,0 +1,85 @@
+import tempfile
+import os
+
+from thor.taskqueue import tasks
+
+
+class MockBucket():
+    def __init__(self):
+        self.blobs = {}
+
+    def blob(self, name):
+        if name in self.blobs:
+            return self.blobs[name]
+        blob = MockBlob()
+        self.blobs[name] = blob
+        return blob
+
+
+class MockBlob():
+    def __init__(self):
+        content = b""
+
+    def upload_from_string(self, content):
+        self.content = content.encode()
+
+    def upload_from_filename(self, filename):
+        with open(filename, "rb") as f:
+            self.content = f.read()
+
+class MockChannel():
+    def __init__(self):
+        pass
+
+
+def test_upload_failure():
+    bucket = MockBucket()
+    channel = MockChannel()
+    task = tasks.Task("job-id", "task-id", bucket, channel, 1)
+
+    try:
+        raise ValueError("a genuine exception!")
+    except ValueError as e:
+        exception = e
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(os.path.join(tempdir, "data-example"), "wb") as temp_data_file:
+            temp_data_file.write(b"test data upload")
+        task._upload_failure(bucket, tempdir, exception)
+
+    # Should have uploaded an error message
+    output_root = tasks._task_output_path("job-id", "task-id" )
+    error_blob = bucket.blobs[output_root + "/error_message.txt"]
+    assert b"a genuine exception!" in error_blob.content
+
+    data_blob = bucket.blobs[output_root + "/./data-example"]
+    assert data_blob.content == b"test data upload"
+
+
+def test_upload_failure_multiple_errors():
+    bucket = MockBucket()
+    channel = MockChannel()
+    task = tasks.Task("job-id", "task-id", bucket, channel, 1)
+
+    try:
+        raise ValueError("a genuine exception!")
+    except ValueError as e:
+        try:
+            raise AssertionError("an internal one") from e
+        except AssertionError as e2:
+            exception = e2
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(os.path.join(tempdir, "data-example"), "wb") as temp_data_file:
+            temp_data_file.write(b"test data upload")
+        task._upload_failure(bucket, tempdir, exception)
+
+    # Should have uploaded an error message
+    output_root = tasks._task_output_path("job-id", "task-id" )
+    error_blob = bucket.blobs[output_root + "/error_message.txt"]
+    assert b"Multiple errors:" in error_blob.content
+    assert b"a genuine exception!" in error_blob.content
+    assert b"an internal one" in error_blob.content
+
+    data_blob = bucket.blobs[output_root + "/./data-example"]
+    assert data_blob.content == b"test data upload"


### PR DESCRIPTION
When an exception occurs while handling a task, upload a string of the traceback of the exception. If multiple exceptions occur, concatenate them together into a single string.

Fixes an issue @katkiker hit.