### PR TITLE
Use a 12-hour heartbeat timeout for tasks

### DIFF
--- a/runTHORWorker.py
+++ b/runTHORWorker.py
@@ -71,13 +71,40 @@ def main():
             credentials=pika.PlainCredentials(
                 username=args.rabbit_username, password=args.rabbit_password,
             ),
+            heartbeat=use_12_hour_heartbeat,
         ),
         args.queue,
     )
     queue.connect()
-    gcs = GCSClient()
-    worker = Worker(gcs, queue)
-    worker.run_worker_loop(args.poll_interval, args.idle_shutdown_timeout)
+    try:
+        gcs = GCSClient()
+        worker = Worker(gcs, queue)
+        worker.run_worker_loop(args.poll_interval, args.idle_shutdown_timeout)
+    finally:
+        queue.close()
+
+
+def use_12_hour_heartbeat(connection, server_proposal):
+    """
+    Configures a Rabbit connection to use a 12-hour heartbeat interval.
+
+    If a task takes longer than the heartbeat interval, then the rabbit server
+    will kill the connection, since the worker doesn't use a background thread
+    to acknowledge heartbeats - it just runs THOR until complete.
+
+    The default is 60s, which is much too low - THOR tasks that are longer would
+    always result in inability to communicate with Rabbit.
+
+    We could disable heartbeats entirely, but then the Rabbit server would hold
+    lots of broken TCP connections whenever workers exit.
+
+    12 hours is longer than tasks should take, but still finite, so the server
+    won't build up garbage.
+
+    This function conforms to Pika's API for setting a heartbeat, which is why
+    it takes a connection and server proposal, which it ignores.
+    """
+    return 12 * 60 * 60
 
 
 if __name__ == "__main__":

--- a/thor/taskqueue/queue.py
+++ b/thor/taskqueue/queue.py
@@ -94,6 +94,8 @@ class TaskQueueConnection:
             done, receive will return None.
         """
 
+        # Handle any heartbeats.
+        self.connection.process_data_events()
         method, properties, body = self.channel.basic_get(
             queue=self.queue_name,
             auto_ack=False,


### PR DESCRIPTION
Because tasks can take a long time and block the Rabbit connection's thread, we need a very long timeout.

The comment in `runTHORWorker.py` explains more.