### PR TITLE
Return CompletedProcess objects and allow user to specify out_dir

### DIFF
--- a/thor/backend/findorb.py
+++ b/thor/backend/findorb.py
@@ -1,5 +1,5 @@
 import os
-import time
+import uuid
 import json
 import shutil
 import tempfile
@@ -8,6 +8,7 @@ import subprocess
 import numpy as np
 import pandas as pd
 from astropy.time import Time
+from thor.utils import ades
 
 from ..utils import writeToADES
 from .backend import Backend
@@ -112,11 +113,8 @@ class FINDORB(Backend):
         env["HOME"] = temp_dir
         return env
 
-    def _propagateOrbits(self, orbits, t1):
-        """
+    def _propagateOrbits(self, orbits, t1, out_dir=None):
 
-
-        """
         propagated_dfs = []
         with tempfile.TemporaryDirectory() as temp_dir:
 
@@ -124,9 +122,11 @@ class FINDORB(Backend):
             # to prevent bugs with multiple processes writing to the ~/.find_orb/
             # directory
             env = self._setWorkEnvironment(temp_dir)
+            out_dir_ = os.path.join(temp_dir, "propagation")
+            os.makedirs(out_dir_, exist_ok=True)
 
             # Write the desired times out to a file that find_orb understands
-            times_in_file = os.path.join(temp_dir, "times_prop.in")
+            times_in_file = os.path.join(temp_dir, "propagation", "times_prop.in")
             self._writeTimes(
                 times_in_file,
                 t1.tt,
@@ -138,9 +138,9 @@ class FINDORB(Backend):
                 # If you give fo a string for a numbered object it will typically append brackets
                 # automatically which makes retrieving the object's orbit a little more tedious so by making sure
                 # the object ID is not numeric we can work around that.
-                orbit_id_i = f"o{i:08d}"
-                out_dir = os.path.join(temp_dir, "vectors{}".format(orbit_id_i))
-                vectors_txt = os.path.join(out_dir, "vectors.txt")
+                orbit_id_i = orbits.ids[i].astype(str)
+                out_dir_i = os.path.join(out_dir_, orbit_id_i)
+                vectors_txt = os.path.join(out_dir_i, "vectors.txt")
 
                 # Format the state vector into the type understood by find_orb
                 fo_orbit = "-v{},{}".format(
@@ -152,19 +152,19 @@ class FINDORB(Backend):
                 call = [
                     "fo",
                     "-o",
-                    "o{}".format(orbit_id_i),
+                    orbit_id_i,
                     fo_orbit,
                     "-E",
                     "0",
                     "-C",
                     "Sun",
                     "-O",
-                    out_dir,
+                    out_dir_i,
                     "-e",
                     vectors_txt,
                     "-D",
                     self.config_file,
-                    "EPHEM_STEP_SIZE=t{}".format(times_in_file)
+                    f"EPHEM_STEP_SIZE=t{times_in_file}"
                 ]
                 ret = subprocess.run(
                     call,
@@ -172,7 +172,7 @@ class FINDORB(Backend):
                     env=env,
                     cwd=temp_dir,
                     check=False,
-                    capture_output=True
+                    capture_output=True,
                 )
 
                 if (ret.returncode != 0):
@@ -200,6 +200,17 @@ class FINDORB(Backend):
 
                 propagated_dfs.append(df)
 
+                if out_dir is not None:
+                    os.makedirs(out_dir, exist_ok=True)
+                    shutil.copytree(
+                        temp_dir,
+                        out_dir,
+                        ignore=shutil.ignore_patterns(
+                            ".find_orb",
+                        ),
+                        dirs_exist_ok=True
+                    )
+
             propagated = pd.concat(propagated_dfs, ignore_index=True)
             propagated["mjd_tdb"] = Time(
                 propagated["jd_tt"].values,
@@ -213,7 +224,7 @@ class FINDORB(Backend):
 
         return propagated
 
-    def _generateEphemeris(self, orbits, observers):
+    def _generateEphemeris(self, orbits, observers, out_dir=None):
         ephemeris_dfs = []
         with tempfile.TemporaryDirectory() as temp_dir:
 
@@ -224,8 +235,11 @@ class FINDORB(Backend):
 
             for observatory_code, observation_times in observers.items():
 
+                out_dir_ = os.path.join(temp_dir, "ephemeris", observatory_code)
+                os.makedirs(out_dir_, exist_ok=True)
+
                 # Write the desired times out to a file that find_orb understands
-                times_in_file = os.path.join(temp_dir, "times_eph.in")
+                times_in_file = os.path.join(out_dir_, "times_eph.in")
                 self._writeTimes(
                     times_in_file,
                     observation_times.tt,
@@ -256,9 +270,9 @@ class FINDORB(Backend):
                     # If you give fo a string for a numbered object it will typically append brackets
                     # automatically which makes retrieving the object's orbit a little more tedious so by making sure
                     # the object ID is not numeric we can work around that.
-                    orbit_id_i = f"o{i:08d}"
-                    out_dir = os.path.join(temp_dir, "ephemeris{}_{}".format(orbit_id_i, observatory_code))
-                    ephemeris_txt = os.path.join(out_dir, "ephemeris.txt")
+                    orbit_id_i = orbits.ids[i].astype(str)
+                    out_dir_i = os.path.join(out_dir_, orbit_id_i)
+                    ephemeris_txt = os.path.join(out_dir_i, "ephemeris.txt")
 
                     # Format the state vector into the type understood by find_orb
                     fo_orbit = "-v{},{}".format(
@@ -272,21 +286,21 @@ class FINDORB(Backend):
                     call = [
                         "fo",
                         "-o",
-                        "o{}".format(orbit_id_i),
+                        orbit_id_i,
                         fo_orbit,
                         "-C",
-                        "{}".format(observatory_code),
+                        observatory_code,
                         "-O",
-                        out_dir,
+                        out_dir_i,
                         "-e",
                         ephemeris_txt,
                         "-D",
                         self.config_file,
-                        "EPHEM_STEP_SIZE=t{}".format(times_in_file),
-                        "JSON_EPHEM_NAME={}".format(os.path.join(temp_dir, "eph%p_%c.json")),
-                        "JSON_ELEMENTS_NAME={}".format(os.path.join(temp_dir, "ele%p.json")),
-                        "JSON_SHORT_ELEMENTS={}".format(os.path.join(temp_dir, "short%p.json")),
-                        "JSON_COMBINED_NAME={}".format(os.path.join(temp_dir, "com%p_%c.json"))
+                        f"EPHEM_STEP_SIZE=t{times_in_file}",
+                        f"JSON_EPHEM_NAME={os.path.join(out_dir_i, 'eph.json')}",
+                        f"JSON_ELEMENTS_NAME={os.path.join(out_dir_i, 'ele.json')}",
+                        f"JSON_SHORT_ELEMENTS={os.path.join(out_dir_i, 'short.json')}",
+                        f"JSON_COMBINED_NAME={os.path.join(out_dir_i, 'com.json')}"
                     ]
 
                     ret = subprocess.run(
@@ -317,17 +331,26 @@ class FINDORB(Backend):
 
                     ephemeris_dfs.append(ephemeris)
 
+            if out_dir is not None:
+                os.makedirs(out_dir, exist_ok=True)
+                shutil.copytree(
+                    temp_dir,
+                    out_dir,
+                    ignore=shutil.ignore_patterns(
+                        ".find_orb",
+                        "eph_json.txt"
+                    ),
+                    dirs_exist_ok=True
+                )
+
         # Combine ephemeris data frames and sort by orbit ID,
         # observatory code and observation time, then reset the
         # index
         ephemeris = pd.concat(ephemeris_dfs)
         ephemeris.sort_values(
             by=["orbit_id", "observatory_code", "jd_utc"],
-            inplace=True
-        )
-        ephemeris.reset_index(
             inplace=True,
-            drop=True
+            ignore_index=True
         )
 
         # Extract observation times and convert them to MJDs
@@ -352,7 +375,7 @@ class FINDORB(Backend):
 
         return ephemeris
 
-    def _orbitDetermination(self, observations):
+    def _orbitDetermination(self, observations, out_dir=None, ades_kwargs={}):
 
         ids = []
         epochs = []
@@ -422,20 +445,26 @@ class FINDORB(Backend):
                 # If you give fo a string for a numbered object it will typically append brackets
                 # automatically which makes retrieving the object's orbit a little more tedious so by making sure
                 # the object ID is not numeric we can work around that.
-                orbit_id_i = f"o{i:08d}"
+                orbit_id_short = f"o{i:08d}"
+                if "orbit_id" in _observations.columns:
+                    orbit_id_i = orbit_id
+                else:
+                    orbit_id_i = orbit_id_short
 
-                observations_file = os.path.join(temp_dir, "_observations_{}.psv".format(orbit_id_i))
-                out_dir = os.path.join(temp_dir, "od_{}".format(orbit_id_i))
+                out_dir_i = os.path.join(temp_dir, "orbit_determination", orbit_id_i)
+                os.makedirs(out_dir_i, exist_ok=True)
+
+                observations_file = os.path.join(temp_dir, "orbit_determination", f"{'_'.join(orbit_id_i.split(' '))}.psv")
 
                 mask = _observations[id_col].isin([orbit_id])
                 object_observations = _observations[mask].copy()
-                object_observations.loc[:, id_col] = orbit_id_i
+                object_observations.loc[:, id_col] = orbit_id_short
                 object_observations.reset_index(inplace=True, drop=True)
 
                 writeToADES(
                     object_observations,
                     observations_file,
-                    mjd_scale="utc"
+                    **ades_kwargs
                 )
 
                 last_observation = Time(
@@ -447,8 +476,8 @@ class FINDORB(Backend):
                     "fo",
                     observations_file,
                     "-O",
-                    out_dir,
-                    "-tEjd{}".format(last_observation.tt.jd),
+                    out_dir_i,
+                    f"-tEjd{last_observation.tt.jd}",
                     "-j",
                     "-D",
                     self.config_file,
@@ -463,7 +492,7 @@ class FINDORB(Backend):
                     capture_output=True
                 )
 
-                covar_json = os.path.join(out_dir, "covar.json")
+                covar_json = os.path.join(out_dir_i, "covar.json")
                 if (os.path.exists(covar_json)) and ret.returncode == 0:
                     with open(covar_json) as f:
                         covar_data = json.load(f)
@@ -475,12 +504,12 @@ class FINDORB(Backend):
                     state = np.zeros(6) * np.NaN
                     covariance_matrix = np.zeros((6,6)) * np.NaN
 
-                total_json = os.path.join(out_dir, "total.json")
+                total_json = os.path.join(out_dir_i, "total.json")
                 if (os.path.exists(total_json)) and ret.returncode == 0:
                     with open(total_json) as f:
                         data = json.load(f)
                         residuals = pd.DataFrame(
-                            data["objects"][orbit_id_i]["observations"]["residuals"]
+                            data["objects"][orbit_id_short]["observations"]["residuals"]
                         )
                         residuals.sort_values(
                             by=["JD", "obscode"],
@@ -494,6 +523,18 @@ class FINDORB(Backend):
                 epochs.append(epoch)
                 orbits.append(state)
                 covariances.append(covariance_matrix)
+
+                if out_dir is not None:
+                    os.makedirs(out_dir, exist_ok=True)
+                    shutil.copytree(
+                        temp_dir,
+                        out_dir,
+                        ignore=shutil.ignore_patterns(
+                            ".find_orb",
+                            "eph_json.txt"
+                        ),
+                        dirs_exist_ok=True
+                    )
 
         orbits = np.vstack(orbits)
 


### PR DESCRIPTION
This PR adds a few minor changes to the findorb.py wrapper to allow the user to define an output directory where input and output files should be saved. CompletedProcess objects from `subprocess` are also returned to the user. 