### PR TITLE
Add concurrent.future.ProcessPoolExecutor as a parallel backend

### DIFF
--- a/thor/backend/backend.py
+++ b/thor/backend/backend.py
@@ -9,6 +9,7 @@ os.environ["NUMEXPR_NUM_THREADS"] = "1"
 import copy
 import logging
 import multiprocessing as mp
+import concurrent.futures as cf
 
 import pandas as pd
 
@@ -112,7 +113,7 @@ class Backend:
         raise NotImplementedError(err)
 
     def propagateOrbits(
-        self, orbits, t1, chunk_size=100, num_jobs=1, parallel_backend="mp"
+        self, orbits, t1, chunk_size=100, num_jobs=1, parallel_backend="cf"
     ):
         """
         Propagate each orbit in orbits to each time in t1.
@@ -128,8 +129,8 @@ class Backend:
         num_jobs : int, optional
             Number of jobs to launch.
         parallel_backend : str, optional
-            Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-            module ('mp').
+            Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's concurrent.futures
+            module ('cf').
 
         Returns
         -------
@@ -160,7 +161,7 @@ class Backend:
                     p.append(propagation_worker_ray.remote(o, t, b))
                 propagated_dfs = ray.get(p)
 
-            else:  # parallel_backend == "mp"
+            elif parallel_backend == "mp":
                 p = mp.Pool(
                     processes=num_workers,
                     initializer=_initWorker,
@@ -175,6 +176,20 @@ class Backend:
                     ),
                 )
                 p.close()
+
+            elif parallel_backend == "cf":
+                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                    propagated_dfs = executor.map(
+                        propagation_worker,
+                        orbits_split,
+                        t1_duplicated,
+                        backend_duplicated,
+                    )
+
+            else:
+                raise ValueError(
+                    "parallel_backend must be one of {'ray', 'mp', 'cf'}."
+                )
 
             propagated = pd.concat(propagated_dfs)
             propagated.reset_index(drop=True, inplace=True)
@@ -201,7 +216,7 @@ class Backend:
         test_orbit=None,
         chunk_size=100,
         num_jobs=1,
-        parallel_backend="mp",
+        parallel_backend="cf",
     ):
         """
         Generate ephemerides for each orbit in orbits as observed by each observer
@@ -220,8 +235,8 @@ class Backend:
         num_jobs : int, optional
             Number of jobs to launch.
         parallel_backend : str, optional
-            Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-            module ('mp').
+            Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's concurrent.futures
+            module ('cf').
 
         Returns
         -------
@@ -257,7 +272,7 @@ class Backend:
                     p.append(ephemeris_worker_ray.remote(o, t, b))
                 ephemeris_dfs = ray.get(p)
 
-            else:  # parallel_backend == "mp"
+            elif parallel_backend == "mp"
                 p = mp.Pool(
                     processes=num_workers,
                     initializer=_initWorker,
@@ -272,6 +287,20 @@ class Backend:
                     ),
                 )
                 p.close()
+
+            elif parallel_backend == "cf":
+                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                    ephemeris_dfs = executor.map(
+                        ephemeris_worker,
+                        orbits_split,
+                        observers_duplicated,
+                        backend_duplicated,
+                    )
+
+            else:
+                raise ValueError(
+                    "parallel_backend must be one of {'ray', 'mp', 'cf'}."
+                )
 
             ephemeris = pd.concat(ephemeris_dfs)
             ephemeris.reset_index(drop=True, inplace=True)
@@ -341,7 +370,7 @@ class Backend:
         raise NotImplementedError(err)
 
     def orbitDetermination(
-        self, observations, chunk_size=10, num_jobs=1, parallel_backend="mp"
+        self, observations, chunk_size=10, num_jobs=1, parallel_backend="cf"
     ):
         """
         Run orbit determination on the input observations. These observations
@@ -360,8 +389,8 @@ class Backend:
         num_jobs : int, optional
             Number of jobs to launch.
         parallel_backend : str, optional
-            Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-            module ('mp').
+            Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's multiprocessing
+            module ('cf').
         """
         unique_objs = observations["obj_id"].unique()
         observations_split = [
@@ -391,7 +420,7 @@ class Backend:
                 od.append(orbitDetermination_worker_ray.remote(o, b))
             od_orbits_dfs = ray.get(od)
 
-        else:  # parallel_backend == "mp"
+        elif parallel_backend == "mp":
             p = mp.Pool(
                 processes=num_workers,
                 initializer=_initWorker,
@@ -405,6 +434,19 @@ class Backend:
                 ),
             )
             p.close()
+
+        elif parallel_backend == "cf":
+            with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                od_orbits_dfs = executor.map(
+                    orbitDetermination_worker,
+                    observations_split,
+                    backend_duplicated,
+                )
+
+        else:
+            raise ValueError(
+                "parallel_backend must be one of {'ray', 'mp', 'cf'}."
+            )
 
         od_orbits = pd.concat(od_orbits_dfs, ignore_index=True)
         return od_orbits

--- a/thor/backend/backend.py
+++ b/thor/backend/backend.py
@@ -6,10 +6,10 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
+import concurrent.futures as cf
 import copy
 import logging
 import multiprocessing as mp
-import concurrent.futures as cf
 
 import pandas as pd
 
@@ -178,7 +178,9 @@ class Backend:
                 p.close()
 
             elif parallel_backend == "cf":
-                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                with cf.ProcessPoolExecutor(
+                    max_workers=num_workers, initializer=_initWorker
+                ) as executor:
                     propagated_dfs = executor.map(
                         propagation_worker,
                         orbits_split,
@@ -187,9 +189,7 @@ class Backend:
                     )
 
             else:
-                raise ValueError(
-                    "parallel_backend must be one of {'ray', 'mp', 'cf'}."
-                )
+                raise ValueError("parallel_backend must be one of {'ray', 'mp', 'cf'}.")
 
             propagated = pd.concat(propagated_dfs)
             propagated.reset_index(drop=True, inplace=True)
@@ -272,7 +272,7 @@ class Backend:
                     p.append(ephemeris_worker_ray.remote(o, t, b))
                 ephemeris_dfs = ray.get(p)
 
-            elif parallel_backend == "mp"
+            elif parallel_backend == "mp":
                 p = mp.Pool(
                     processes=num_workers,
                     initializer=_initWorker,
@@ -289,7 +289,9 @@ class Backend:
                 p.close()
 
             elif parallel_backend == "cf":
-                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                with cf.ProcessPoolExecutor(
+                    max_workers=num_workers, initializer=_initWorker
+                ) as executor:
                     ephemeris_dfs = executor.map(
                         ephemeris_worker,
                         orbits_split,
@@ -298,9 +300,7 @@ class Backend:
                     )
 
             else:
-                raise ValueError(
-                    "parallel_backend must be one of {'ray', 'mp', 'cf'}."
-                )
+                raise ValueError("parallel_backend must be one of {'ray', 'mp', 'cf'}.")
 
             ephemeris = pd.concat(ephemeris_dfs)
             ephemeris.reset_index(drop=True, inplace=True)
@@ -436,7 +436,9 @@ class Backend:
             p.close()
 
         elif parallel_backend == "cf":
-            with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+            with cf.ProcessPoolExecutor(
+                max_workers=num_workers, initializer=_initWorker
+            ) as executor:
                 od_orbits_dfs = executor.map(
                     orbitDetermination_worker,
                     observations_split,
@@ -444,9 +446,7 @@ class Backend:
                 )
 
         else:
-            raise ValueError(
-                "parallel_backend must be one of {'ray', 'mp', 'cf'}."
-            )
+            raise ValueError("parallel_backend must be one of {'ray', 'mp', 'cf'}.")
 
         od_orbits = pd.concat(od_orbits_dfs, ignore_index=True)
         return od_orbits

--- a/thor/config.py
+++ b/thor/config.py
@@ -17,7 +17,7 @@ CONTAMINATION_PERCENTAGE: float = 20.0
 BACKEND: str = "PYOORB"
 BACKEND_KWARGS: dict = {}
 NUM_JOBS: str = "auto"
-PARALLEL_BACKEND: str = "mp"
+PARALLEL_BACKEND: str = "cf"
 
 DEFAULT_RANGE_SHIFT_CONFIG = {
     "cell_area": 1000,

--- a/thor/main.py
+++ b/thor/main.py
@@ -6,9 +6,9 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
+import concurrent.futures as cf
 import logging
 import multiprocessing as mp
-import concurrent.futures as cf
 import shutil
 import time
 import uuid
@@ -348,11 +348,18 @@ def rangeAndShift(
             p.close()
 
         elif parallel_backend == "cf":
-            with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+            with cf.ProcessPoolExecutor(
+                max_workers=num_workers, initializer=_initWorker
+            ) as executor:
                 futures = []
-                for observations_i, ephemeris_i in zip(observations_split, ephemeris_split):
+                for observations_i, ephemeris_i in zip(
+                    observations_split, ephemeris_split
+                ):
                     f = executor.submit(
-                        rangeAndShift_worker, observations_i, ephemeris_i, cell_area=cell_area
+                        rangeAndShift_worker,
+                        observations_i,
+                        ephemeris_i,
+                        cell_area=cell_area,
                     )
                     futures.append(f)
 
@@ -360,11 +367,8 @@ def rangeAndShift(
                 for f in cf.as_completed(futures):
                     projected_dfs.append(f.result())
 
-
         else:
-            raise ValueError(
-                "Invalid parallel_backend: {}".format(parallel_backend)
-            )
+            raise ValueError("Invalid parallel_backend: {}".format(parallel_backend))
 
     else:
         projected_dfs = []
@@ -624,7 +628,9 @@ def clusterAndLink(
                 p.close()
 
             elif parallel_backend == "cf":
-                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                with cf.ProcessPoolExecutor(
+                    max_workers=num_workers, initializer=_initWorker
+                ) as executor:
                     futures = []
                     for vxi, vyi in zip(vxx, vyy):
                         f = executor.submit(

--- a/thor/orbits/attribution.py
+++ b/thor/orbits/attribution.py
@@ -6,9 +6,9 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
+import concurrent.futures as cf
 import logging
 import multiprocessing as mp
-import concurrent.futures as cf
 import time
 from functools import partial
 
@@ -277,9 +277,13 @@ def attributeObservations(
             p.close()
 
         elif parallel_backend == "cf":
-            with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+            with cf.ProcessPoolExecutor(
+                max_workers=num_workers, initializer=_initWorker
+            ) as executor:
                 futures = []
-                for observations_c in yieldChunks(observations, observations_chunk_size):
+                for observations_c in yieldChunks(
+                    observations, observations_chunk_size
+                ):
                     for orbit_c in orbits.split(orbits_chunk_size):
                         futures.append(
                             executor.submit(

--- a/thor/orbits/ephemeris.py
+++ b/thor/orbits/ephemeris.py
@@ -13,7 +13,7 @@ def generateEphemeris(
     test_orbit=None,
     chunk_size=1,
     num_jobs=1,
-    parallel_backend="mp",
+    parallel_backend="cf",
 ):
     """
     Generate ephemeris for the orbits and the given observatories.
@@ -40,8 +40,8 @@ def generateEphemeris(
     num_jobs : int, optional
         Number of jobs to launch.
     parallel_backend : str, optional
-        Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-        module ('mp').
+        Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's concurrent.futures
+        module ('cf').
 
     Returns
     -------

--- a/thor/orbits/iod.py
+++ b/thor/orbits/iod.py
@@ -6,9 +6,9 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
+import concurrent.futures as cf
 import logging
 import multiprocessing as mp
-import concurrent.futures as cf
 import time
 import uuid
 from functools import partial
@@ -736,7 +736,9 @@ def initialOrbitDetermination(
                 iod_orbit_members_dfs = results[1]
 
             elif parallel_backend == "cf":
-                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                with cf.ProcessPoolExecutor(
+                    max_workers=num_workers, initializer=_initWorker
+                ) as executor:
                     futures = []
                     for observations_i in yieldChunks(observations_split, chunk_size):
                         futures.append(

--- a/thor/orbits/iod.py
+++ b/thor/orbits/iod.py
@@ -8,6 +8,7 @@ os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
 import logging
 import multiprocessing as mp
+import concurrent.futures as cf
 import time
 import uuid
 from functools import partial
@@ -529,7 +530,7 @@ def initialOrbitDetermination(
     backend_kwargs={},
     chunk_size=1,
     num_jobs=1,
-    parallel_backend="mp",
+    parallel_backend="cf",
 ):
     """
     Run initial orbit determination on linkages found in observations.
@@ -586,8 +587,7 @@ def initialOrbitDetermination(
     num_jobs : int, optional
         Number of jobs to launch.
     parallel_backend : str, optional
-        Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-        module ('mp').
+        Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's concurrent.futures module ('cf').
 
     Returns
     -------
@@ -699,7 +699,7 @@ def initialOrbitDetermination(
                 iod_orbits_dfs = ray.get(iod_orbits_oids)
                 iod_orbit_members_dfs = ray.get(iod_orbit_members_oids)
 
-            else:  # parallel_backend == "mp"
+            elif parallel_backend == "mp":
 
                 chunk_size_ = calcChunkSize(
                     num_linkages, num_workers, chunk_size, min_chunk_size=1
@@ -734,6 +734,38 @@ def initialOrbitDetermination(
                 results = list(zip(*results))
                 iod_orbits_dfs = results[0]
                 iod_orbit_members_dfs = results[1]
+
+            elif parallel_backend == "cf":
+                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                    futures = []
+                    for observations_i in yieldChunks(observations_split, chunk_size):
+                        futures.append(
+                            executor.submit(
+                                iod_worker,
+                                observations_i,
+                                observation_selection_method=observation_selection_method,
+                                rchi2_threshold=rchi2_threshold,
+                                min_obs=min_obs,
+                                min_arc_length=min_arc_length,
+                                contamination_percentage=contamination_percentage,
+                                iterate=iterate,
+                                light_time=light_time,
+                                linkage_id_col=linkage_id_col,
+                                backend=backend,
+                                backend_kwargs=backend_kwargs,
+                            )
+                        )
+
+                    iod_orbits_dfs = []
+                    iod_orbit_members_dfs = []
+                    for f in cf.as_completed(futures):
+                        iod_orbits_df, iod_orbit_members_df = f.result()
+                        iod_orbits_dfs.append(iod_orbits_df)
+                        iod_orbit_members_dfs.append(iod_orbit_members_df)
+            else:
+                raise ValueError(
+                    f"Unknown parallel backend: {parallel_backend}. Must be one of: 'ray', 'mp', 'cf'."
+                )
 
         else:
 

--- a/thor/orbits/od.py
+++ b/thor/orbits/od.py
@@ -6,10 +6,10 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
+import concurrent.futures as cf
 import copy
 import logging
 import multiprocessing as mp
-import concurrent.futures as cf
 import time
 from functools import partial
 
@@ -724,11 +724,13 @@ def differentialCorrection(
                 od_orbit_members_dfs = results[1]
 
             elif parallel_backend == "cf":
-                with cf.ProcessPoolExecutor(max_workers=num_workers, initializer=_initWorker) as executor:
+                with cf.ProcessPoolExecutor(
+                    max_workers=num_workers, initializer=_initWorker
+                ) as executor:
                     futures = []
                     for orbits_i, observations_i in zip(
-                            yieldChunks(orbits_split, chunk_size),
-                            yieldChunks(observations_split, chunk_size),
+                        yieldChunks(orbits_split, chunk_size),
+                        yieldChunks(observations_split, chunk_size),
                     ):
                         futures.append(
                             executor.submit(

--- a/thor/orbits/propagate.py
+++ b/thor/orbits/propagate.py
@@ -13,7 +13,7 @@ def propagateOrbits(
     backend_kwargs={},
     chunk_size=1,
     num_jobs=1,
-    parallel_backend="mp",
+    parallel_backend="cf",
 ):
     """
     Propagate orbits using desired backend.
@@ -38,8 +38,8 @@ def propagateOrbits(
     num_jobs : int, optional
         Number of jobs to launch.
     parallel_backend : str, optional
-        Which parallelization backend to use {'ray', 'mp'}. Defaults to using Python's multiprocessing
-        module ('mp').
+        Which parallelization backend to use {'ray', 'mp', 'cf'}. Defaults to using Python's concurrent.futures
+        module ('cf').
 
     Returns
     -------

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -44,7 +44,7 @@ def test_rangeAndShift():
             cell_area=0.1,
             backend="PYOORB",
             num_jobs=1,
-            parallel_backend="mp",
+            parallel_backend="cf",
         )
         analyis_projected_observations = projected_observations.merge(
             preprocessed_associations, how="left", on="obs_id"
@@ -109,7 +109,7 @@ def test_clusterAndLink():
             cell_area=0.1,
             backend="PYOORB",
             num_jobs=1,
-            parallel_backend="mp",
+            parallel_backend="cf",
         )
         analyis_projected_observations = projected_observations.merge(
             preprocessed_associations, how="left", on="obs_id"

--- a/thor/utils/multiprocessing.py
+++ b/thor/utils/multiprocessing.py
@@ -109,7 +109,7 @@ def _checkParallel(num_jobs, parallel_backend):
     num_jobs : {None, "auto", int}
         Number of jobs to launch.
     parallel_backend : str
-        Name of backend. Should be one of {'ray', 'mp'}.
+        Name of backend. Should be one of {'ray', 'mp', 'cf'}.
 
     Returns
     -------
@@ -120,14 +120,14 @@ def _checkParallel(num_jobs, parallel_backend):
 
     Raises
     ------
-    ValueError : If parallel_backend is not one of {'ray', 'mp'}.
+    ValueError : If parallel_backend is not one of {'ray', 'mp', 'cf'}.
     """
     if isinstance(num_jobs, str) or (num_jobs is None) or (num_jobs > 1):
 
         # Check that pareallel_backend is one of the support types
-        backends = ["ray", "mp"]
+        backends = ["ray", "mp", "cf"]
         if parallel_backend not in backends:
-            err = "parallel_backend should be one of {'ray', 'mp'}"
+            err = "parallel_backend should be one of {'ray', 'mp', 'cf'}"
             raise ValueError(err)
 
         enable_parallel = True


### PR DESCRIPTION
concurrent.futures.ProcessPoolExecutor is a lot like multiprocessing.Pool, but it is able to detect when its worker processes exit unexpectedly. When that happens in
multiprocessing.Pool, the program enters a deadlock and cannot recover, which is catastrophic for THOR. For concurrent.futures, it at least raises an exception.

There's no effort here to recover from those exceptions, but at least the program will terminate.

Crashes of this kind seem to happen mostly when calling pyoorb.