### PR TITLE
Fix range_and_transform for orbits interior to the observer's orbit

### DIFF
--- a/thor/observations/tests/test_filters.py
+++ b/thor/observations/tests/test_filters.py
@@ -53,7 +53,7 @@ def fixed_observers():
 @pytest.fixture
 def fixed_ephems(fixed_test_orbit, fixed_observers):
     prop = PYOORB()
-    return prop.generate_ephemeris(fixed_test_orbit.orbit, fixed_observers).left_table
+    return prop.generate_ephemeris(fixed_test_orbit.orbit, fixed_observers)
 
 
 @pytest.fixture

--- a/thor/orbit.py
+++ b/thor/orbit.py
@@ -244,7 +244,15 @@ class TestOrbit:
         states : `~thor.orbit.TestOrbitEphemeris`
             Table containing the ephemeris of the test orbit, its aberrated state vector, and the
             observer coordinates at each unique time of the observations.
+
+        Raises
+        ------
+        ValueError
+            If the observations are empty.
         """
+        if len(observations) == 0:
+            raise ValueError("Observations must not be empty.")
+
         if self._is_cache_fresh(observations):
             logger.debug(
                 "Test orbit ephemeris cache is fresh. Returning cached states."

--- a/thor/orbit.py
+++ b/thor/orbit.py
@@ -332,8 +332,8 @@ class TestOrbit:
             observations_i = link.select_right(state_id)
             detections_i = observations_i.detections
 
-            # Get the heliocentric distance of the object at the time of the exposure
-            r_mag = ephemeris_i.ephemeris.aberrated_coordinates.r_mag[0]
+            # Get the heliocentric position vector of the object at the time of the exposure
+            r = ephemeris_i.ephemeris.aberrated_coordinates.r[0]
 
             # Get the observer's heliocentric coordinates
             observer_i = ephemeris_i.observer
@@ -373,7 +373,7 @@ class TestOrbit:
                     id=detections_i.id,
                     exposure_id=detections_i.exposure_id,
                     coordinates=assume_heliocentric_distance(
-                        r_mag, coords, observer_i.coordinates
+                        r, coords, observer_i.coordinates
                     ),
                     state_id=observations_i.state_id,
                 )
@@ -384,7 +384,7 @@ class TestOrbit:
 
 
 def assume_heliocentric_distance(
-    r_mag: float, coords: SphericalCoordinates, origin_coords: CartesianCoordinates
+    r: np.ndarray, coords: SphericalCoordinates, origin_coords: CartesianCoordinates
 ) -> SphericalCoordinates:
     """
     Given a heliocentric distance, for all coordinates that do not have a topocentric distance defined (rho), calculate
@@ -392,10 +392,11 @@ def assume_heliocentric_distance(
 
     Parameters
     ----------
-    r_mag : float
-        Heliocentric distance to assume for the coordinates with missing topocentric distance. This is
-        typically the same distance as the heliocentric distance of test orbit at the time
-        of the coordinates.
+    r_mag : `~numpy.ndarray` (3)
+        Heliocentric position vector from which to assume each coordinate lies at the same heliocentric distance.
+        In cases where the heliocentric distance is less than the heliocentric distance of the origin, the topocentric
+        distance will be calculated such that the topocentric position vector is closest to the heliocentric position
+        vector.
     coords : `~adam_core.coordinates.spherical.SphericalCoordinates`
         Coordinates to assume the heliocentric distance for.
     origin_coords : `~adam_core.coordinates.cartesian.CartesianCoordinates`
@@ -408,6 +409,8 @@ def assume_heliocentric_distance(
     """
     assert len(origin_coords) == 1
     assert np.all(origin_coords.origin == OriginCodes.SUN)
+
+    r_mag = np.linalg.norm(r)
 
     # Extract the topocentric distance and topocentric radial velocity from the coordinates
     rho = coords.rho.to_numpy(zero_copy_only=False)
@@ -428,10 +431,27 @@ def assume_heliocentric_distance(
     # Calculate the topocentric distance such that the heliocentric distance to the coordinate
     # is r_mag
     dotprod = np.sum(unit_vectors * origin_coords.r, axis=1)
-    delta = -dotprod + np.sqrt(dotprod**2 + r_mag**2 - origin_coords.r_mag**2)
+    sqrt = np.sqrt(dotprod**2 + r_mag**2 - origin_coords.r_mag**2)
+    delta_p = -dotprod + sqrt
+    delta_n = -dotprod - sqrt
 
     # Where rho was not defined, replace it with the calculated topocentric distance
-    coords_ec = coords_ec.set_column("rho", np.where(np.isnan(rho), delta, rho))
+    # By default we take the positive solution which applies for all orbits exterior to the
+    # observer's orbit
+    coords_ec = coords_ec.set_column("rho", np.where(np.isnan(rho), delta_p, rho))
+
+    # For cases where the orbit is interior to the observer's orbit there are two valid solutions
+    # for the topocentric distance. In this case, we take the dot product of the heliocentric position
+    # vector with the calculated topocentric position vector. If the dot product is positive, then
+    # that solution is closest to the heliocentric position vector and we take that solution.
+    if np.any(r_mag < origin_coords.r_mag):
+        coords_ec_xyz_p = coords_ec.to_cartesian()
+        dotprod_p = np.sum(coords_ec_xyz_p.r * r, axis=1)
+        coords_ec = coords_ec.set_column(
+            "rho",
+            np.where(np.isnan(rho), np.where(dotprod_p < 0, delta_n, delta_p), rho),
+        )
+
     coords_ec = coords_ec.set_column("vrho", vrho)
 
     return coords_ec

--- a/thor/orbit.py
+++ b/thor/orbit.py
@@ -191,7 +191,7 @@ class TestOrbit:
         observers: Observers,
         propagator: Propagator = PYOORB(),
         max_processes: Optional[int] = 1,
-    ) -> qv.MultiKeyLinkage[Ephemeris, Observers]:
+    ) -> Ephemeris:
         """
         Generate ephemeris for this test orbit at the given observers.
 
@@ -206,9 +206,7 @@ class TestOrbit:
 
         Returns
         -------
-        ephemeris : qv.MultiKeyLinkage[
-                `~adam_core.orbits.ephemeris.Ephemeris`,
-                `~adam_core.observers.observers.Observers`]
+        ephemeris : `~adam_core.orbits.ephemeris.Ephemeris`
             The ephemeris of the test orbit at the given observers.
         """
         return propagator.generate_ephemeris(
@@ -267,7 +265,7 @@ class TestOrbit:
         # Generate ephemerides for each unique state and then sort by time and code
         ephemeris = self.generate_ephemeris(
             observers, propagator=propagator, max_processes=max_processes
-        ).left_table
+        )
         ephemeris = ephemeris.sort_by(
             by=[
                 "coordinates.time.days",

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -49,6 +49,15 @@ def orbits():
     return make_real_orbits()
 
 
+def test_Orbit_generate_ephemeris_from_observations_empty(orbits):
+    # Test that when passed empty observations, TestOrbit.generate_ephemeris_from_observations
+    # returns a Value Error
+    observations = Observations.empty()
+    test_orbit = THORbit.from_orbits(orbits[0])
+    with pytest.raises(ValueError, match="Observations must not be empty."):
+        test_orbit.generate_ephemeris_from_observations(observations)
+
+
 @pytest.mark.parametrize("object_id", OBJECT_IDS)
 def test_range_and_transform(object_id, orbits, observations):
 

--- a/thor/tests/test_orbit.py
+++ b/thor/tests/test_orbit.py
@@ -40,9 +40,10 @@ def test_assume_heliocentric_distance_missing_rho():
     # detection should have a heliocentric distance of 2.5 au (as rho)
     # Since the origin is the Sun the heliocentric distance is also the
     # topocentric distance
-    r_mag = 3.0
-    coords_assumed = assume_heliocentric_distance(r_mag, coords, origin_coords)
-    np.testing.assert_equal(coords_assumed.rho, np.array([r_mag, rho[1]]))
+    r = np.array([3.0, 0.0, 0.0])
+    r_mag = np.linalg.norm(r)
+    coords_assumed = assume_heliocentric_distance(r, coords, origin_coords)
+    np.testing.assert_equal(coords_assumed.rho, np.array([r[0], rho[1]]))
 
 
 def test_assume_heliocentric_distance_zero_origin():
@@ -80,8 +81,9 @@ def test_assume_heliocentric_distance_zero_origin():
     # should have a heliocentric distance of 3 au (as rho)
     # Since the origin is the Sun the heliocentric distance is also the
     # topocentric distance
-    r_mag = 3.0
-    coords_assumed = assume_heliocentric_distance(r_mag, coords, origin_coords)
+    r = np.array([3.0, 0.0, 0.0])
+    r_mag = np.linalg.norm(r)
+    coords_assumed = assume_heliocentric_distance(r, coords, origin_coords)
     np.testing.assert_equal(coords_assumed.rho, r_mag * np.ones(num_detections))
 
 
@@ -120,8 +122,9 @@ def test_assume_heliocentric_distance():
     # point should have topocentric distance sqrt(2) - 1 au (as rho), and the South
     # point should have a topocentric distance of sqrt(2) + 1 au (on the opposite side of the
     # Sun)
-    r_mag = np.sqrt(2)
-    coords_assumed = assume_heliocentric_distance(r_mag, coords, origin_coords)
+    r = np.array([1.0, 1.0, 0.0])
+    r_mag = np.linalg.norm(r)
+    coords_assumed = assume_heliocentric_distance(r, coords, origin_coords)
     rho_assumed = coords_assumed.rho.to_numpy()
-    rho_expected = np.array([1.0, 1.0, np.sqrt(2) - 1, 1.0, np.sqrt(2) + 1, 1.0])
+    rho_expected = np.array([1.0, 1.0, r_mag - 1, 1.0, r_mag + 1, 1.0])
     np.testing.assert_almost_equal(rho_assumed, rho_expected)


### PR DESCRIPTION
Orbits entirely interior to the observer's orbit will have two possible solutions that intersect the orbit when calculating the topocentric distance.

With this PR we now select the solution closest to the test orbit's position vector. 

However, when the relative observing geometry is such that the two solutions are nearly parallel (nearly perpendicular to the line of sight which is itself nearly tangential to the object's orbit) then solutions appear to be more numerically sensitive. For 2020 AV2, theta_x and theta_y
are typically ~1e-5 degrees (~100 milliarcseconds), however, in this instance of observing geometry theta_x degrades to ~1e-4 degrees (~1 arcsec) while theta_y remains the same.

Orbit configuration for this corner case:
![test_orbit_geometry](https://github.com/moeyensj/thor/assets/4206654/d0740d89-b472-4830-8dc3-a40171a7cc9c)
