### PR TITLE
Add LinkingWindowObservationFilter and change ObservationFilters to yield observations

### DIFF
--- a/.github/workflows/conda-build-lint-test.yml
+++ b/.github/workflows/conda-build-lint-test.yml
@@ -45,3 +45,5 @@ jobs:
         run: pre-commit run --all-files
       - name: Test
         run: pytest . --cov
+      - name: Test Integtation
+        run: pytest . -m "integtation"

--- a/.github/workflows/pip-build-lint-test-coverage.yml
+++ b/.github/workflows/pip-build-lint-test-coverage.yml
@@ -44,6 +44,8 @@ jobs:
         run: pre-commit run --all-files
       - name: Test
         run: pytest . --cov --cov-report xml
+      - name: Test Integtation
+        run: pytest . -m "integration"
       - name: Coverage
         uses: coverallsapp/github-action@v2.0.0
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ test=pytest
 
 [tool:pytest]
 python_functions = test_*
+addopts = -m "not integration"
 
 [isort]
 profile = black

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -89,16 +89,19 @@ def test_range_and_transform(object_id, orbits, observations):
     else:
         tolerance = TOLERANCES["default"]
 
-    # Set a filter to include observations within 1 arcsecond of the predicted position
-    # of the test orbit
-    filters = [TestOrbitRadiusObservationFilter(radius=tolerance)]
-
     # Create a test orbit for this object
     test_orbit = THORbit.from_orbits(orbit)
 
+    # Set a filter to include observations within 1 arcsecond of the predicted position
+    # of the test orbit
+    filters = [TestOrbitRadiusObservationFilter(radius=tolerance)]
+    for filter in filters:
+        observations = filter.apply(observations, test_orbit)
+
     # Run range and transform and make sure we get the correct observations back
     transformed_detections = range_and_transform(
-        test_orbit, observations, filters=filters
+        test_orbit,
+        observations,
     )
     assert len(transformed_detections) == 90
     assert pc.all(

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -116,9 +116,25 @@ def test_range_and_transform(object_id, orbits, observations):
     assert pc.all(pc.equal(obs_ids_actual, obs_ids_expected))
 
 
-# Limit to a single orbit for now
-@pytest.mark.parametrize("object_id", OBJECT_IDS[10:11])
-@pytest.mark.integration_test
+@pytest.mark.parametrize(
+    "object_id",
+    [
+        pytest.param(OBJECT_IDS[0], marks=pytest.mark.xfail(reason="Fails OD")),
+    ]
+    + OBJECT_IDS[1:3]
+    + [
+        pytest.param(OBJECT_IDS[3], marks=pytest.mark.xfail(reason="Fails OD")),
+        pytest.param(OBJECT_IDS[4], marks=pytest.mark.xfail(reason="Fails OD")),
+        pytest.param(OBJECT_IDS[5], marks=pytest.mark.xfail(reason="Fails OD")),
+    ]
+    + [OBJECT_IDS[6]]
+    + [
+        pytest.param(OBJECT_IDS[7], marks=pytest.mark.xfail(reason="Fails OD")),
+        pytest.param(OBJECT_IDS[8], marks=pytest.mark.xfail(reason="Fails OD")),
+    ]
+    + OBJECT_IDS[9:],
+)
+@pytest.mark.integration
 def test_link_test_orbit(object_id, orbits, observations):
 
     orbit = orbits.select("object_id", object_id)


### PR DESCRIPTION
Proposal to change the ObservationFilters so that they yield observations. An example is the LinkingWindowFilter which can yield a sliding window of observations. These filters can then be applied in `link_test_orbit` instead of `range_and_transform`. 

The exact implementation details of link_test_orbit are still TBD given the changes to a yielding model. 