### PR TITLE
Remove tables dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ install_requires =
     scipy
     scikit-learn
     healpy
-    tables
     pyyaml >= 5.1
     spiceypy
     matplotlib


### PR DESCRIPTION
Tables requires system libraries and we aren't using it right now. Recommend we remove it until we decide we need it.