### PR TITLE
Add InputObservations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: v1.1.1
     hooks:
     -   id: mypy
+        exclude: bench/
         additional_dependencies:
           - 'types-pyyaml'
           - 'types-requests'

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     numba
     pandas
     pyarrow >= 14.0.0
-    pydantic
+    pydantic < 2.0.0
     pyyaml >= 5.1
     quivr @ git+https://github.com/moeyensj/quivr@concatenate-empty-attributes
     ray[default]

--- a/thor/checkpointing.py
+++ b/thor/checkpointing.py
@@ -1,0 +1,273 @@
+import logging
+import pathlib
+from typing import Annotated, Dict, Literal, Optional, Type, Union
+
+import pydantic
+import quivr as qv
+import ray
+
+from thor.clusters import ClusterMembers, Clusters
+from thor.observations.observations import Observations
+from thor.orbit_determination.fitted_orbits import FittedOrbitMembers, FittedOrbits
+from thor.range_and_transform import TransformedDetections
+
+logger = logging.getLogger("thor")
+
+
+VALID_STAGES = Literal[
+    "filter_observations",
+    "range_and_transform",
+    "cluster_and_link",
+    "initial_orbit_determination",
+    "differential_correction",
+    "recover_orbits",
+    "complete",
+]
+
+
+class FilterObservations(pydantic.BaseModel):
+    stage: Literal["filter_observations"]
+
+
+class RangeAndTransform(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["range_and_transform"]
+    filtered_observations: Union[Observations, ray.ObjectRef]
+
+
+class ClusterAndLink(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["cluster_and_link"]
+    filtered_observations: Union[Observations, ray.ObjectRef]
+    transformed_detections: TransformedDetections
+
+
+class InitialOrbitDetermination(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["initial_orbit_determination"]
+    filtered_observations: Observations
+    clusters: Clusters
+    cluster_members: ClusterMembers
+
+
+class DifferentialCorrection(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["differential_correction"]
+    filtered_observations: Observations
+    iod_orbits: FittedOrbits
+    iod_orbit_members: FittedOrbitMembers
+
+
+class RecoverOrbits(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["recover_orbits"]
+    filtered_observations: Observations
+    od_orbits: FittedOrbits
+    od_orbit_members: FittedOrbitMembers
+
+
+class Complete(pydantic.BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    stage: Literal["complete"]
+    recovered_orbits: FittedOrbits
+    recovered_orbit_members: FittedOrbitMembers
+
+
+CheckpointData = Annotated[
+    Union[
+        FilterObservations,
+        RangeAndTransform,
+        ClusterAndLink,
+        InitialOrbitDetermination,
+        DifferentialCorrection,
+        RecoverOrbits,
+        Complete,
+    ],
+    pydantic.Field(discriminator="stage"),
+]
+
+# A mapping from stage to model class
+stage_to_model: Dict[str, Type[pydantic.BaseModel]] = {
+    "filter_observations": FilterObservations,
+    "range_and_transform": RangeAndTransform,
+    "cluster_and_link": ClusterAndLink,
+    "initial_orbit_determination": InitialOrbitDetermination,
+    "differential_correction": DifferentialCorrection,
+    "recover_orbits": RecoverOrbits,
+    "complete": Complete,
+}
+
+
+def create_checkpoint_data(stage: VALID_STAGES, **data) -> CheckpointData:
+    """
+    Create checkpoint data from the given stage and data.
+    """
+    model = stage_to_model.get(stage)
+    if model:
+        return model(stage=stage, **data)
+    raise ValueError(f"Invalid stage: {stage}")
+
+
+def load_initial_checkpoint_values(
+    test_orbit_directory: Optional[pathlib.Path] = None,
+) -> CheckpointData:
+    """
+    Check for completed stages and return values from disk if they exist.
+
+    We want to avoid loading objects into memory that are not required.
+    """
+    stage: VALID_STAGES = "filter_observations"
+    # Without a checkpoint directory, we always start at the beginning
+    if test_orbit_directory is None:
+        return create_checkpoint_data(stage)
+
+    # filtered_observations is always needed when it exists
+    filtered_observations_path = pathlib.Path(
+        test_orbit_directory, "filtered_observations.parquet"
+    )
+    # If it doesn't exist, start at the beginning.
+    if not filtered_observations_path.exists():
+        return create_checkpoint_data(stage)
+    logger.info("Found filtered observations")
+    filtered_observations = Observations.from_parquet(filtered_observations_path)
+
+    # Unfortunately we have to reinitialize the times to set the attribute
+    # correctly.
+    filtered_observations = qv.defragment(filtered_observations)
+    filtered_observations = filtered_observations.sort_by(
+        [
+            "coordinates.time.days",
+            "coordinates.time.nanos",
+            "coordinates.origin.code",
+        ]
+    )
+
+    # If the pipeline was started but we have recovered_orbits already, we
+    # are done and should exit early.
+    recovered_orbits_path = pathlib.Path(
+        test_orbit_directory, "recovered_orbits.parquet"
+    )
+    recovered_orbit_members_path = pathlib.Path(
+        test_orbit_directory, "recovered_orbit_members.parquet"
+    )
+    if recovered_orbits_path.exists() and recovered_orbit_members_path.exists():
+        logger.info("Found recovered orbits in checkpoint")
+        recovered_orbits = FittedOrbits.from_parquet(recovered_orbits_path)
+        recovered_orbit_members = FittedOrbitMembers.from_parquet(
+            recovered_orbit_members_path
+        )
+
+        # Unfortunately we have to reinitialize the times to set the attribute
+        # correctly.
+        recovered_orbits = qv.defragment(recovered_orbits)
+        recovered_orbits = recovered_orbits.sort_by(
+            [
+                "coordinates.time.days",
+                "coordinates.time.nanos",
+            ]
+        )
+
+        return create_checkpoint_data(
+            "complete",
+            recovered_orbits=recovered_orbits,
+            recovered_orbit_members=recovered_orbit_members,
+        )
+
+    # Now with filtered_observations available, we can check for the later
+    # stages in reverse order.
+    od_orbits_path = pathlib.Path(test_orbit_directory, "od_orbits.parquet")
+    od_orbit_members_path = pathlib.Path(
+        test_orbit_directory, "od_orbit_members.parquet"
+    )
+    if od_orbits_path.exists() and od_orbit_members_path.exists():
+        logger.info("Found OD orbits in checkpoint")
+        od_orbits = FittedOrbits.from_parquet(od_orbits_path)
+        od_orbit_members = FittedOrbitMembers.from_parquet(od_orbit_members_path)
+
+        # Unfortunately we have to reinitialize the times to set the attribute
+        # correctly.
+        od_orbits = qv.defragment(od_orbits)
+        od_orbits = od_orbits.sort_by(
+            [
+                "coordinates.time.days",
+                "coordinates.time.nanos",
+            ]
+        )
+
+        return create_checkpoint_data(
+            "recover_orbits",
+            filtered_observations=filtered_observations,
+            od_orbits=od_orbits,
+            od_orbit_members=od_orbit_members,
+        )
+
+    iod_orbits_path = pathlib.Path(test_orbit_directory, "iod_orbits.parquet")
+    iod_orbit_members_path = pathlib.Path(
+        test_orbit_directory, "iod_orbit_members.parquet"
+    )
+    if iod_orbits_path.exists() and iod_orbit_members_path.exists():
+        logger.info("Found IOD orbits")
+        iod_orbits = FittedOrbits.from_parquet(iod_orbits_path)
+        iod_orbit_members = FittedOrbitMembers.from_parquet(iod_orbit_members_path)
+
+        # Unfortunately we have to reinitialize the times to set the attribute
+        # correctly.
+        iod_orbits = qv.defragment(iod_orbits)
+        iod_orbits = iod_orbits.sort_by(
+            [
+                "coordinates.time.days",
+                "coordinates.time.nanos",
+            ]
+        )
+
+        return create_checkpoint_data(
+            "differential_correction",
+            filtered_observations=filtered_observations,
+            iod_orbits=iod_orbits,
+            iod_orbit_members=iod_orbit_members,
+        )
+
+    clusters_path = pathlib.Path(test_orbit_directory, "clusters.parquet")
+    cluster_members_path = pathlib.Path(test_orbit_directory, "cluster_members.parquet")
+    if clusters_path.exists() and cluster_members_path.exists():
+        logger.info("Found clusters")
+        clusters = Clusters.from_parquet(clusters_path)
+        cluster_members = ClusterMembers.from_parquet(cluster_members_path)
+
+        return create_checkpoint_data(
+            "initial_orbit_determination",
+            filtered_observations=filtered_observations,
+            clusters=clusters,
+            cluster_members=cluster_members,
+        )
+
+    transformed_detections_path = pathlib.Path(
+        test_orbit_directory, "transformed_detections.parquet"
+    )
+    if transformed_detections_path.exists():
+        logger.info("Found transformed detections")
+        transformed_detections = TransformedDetections.from_parquet(
+            transformed_detections_path
+        )
+
+        return create_checkpoint_data(
+            "cluster_and_link",
+            filtered_observations=filtered_observations,
+            transformed_detections=transformed_detections,
+        )
+
+    return create_checkpoint_data(
+        "range_and_transform", filtered_observations=filtered_observations
+    )

--- a/thor/config.py
+++ b/thor/config.py
@@ -9,8 +9,7 @@ logger = logging.getLogger("thor")
 
 class Config(BaseModel):
     max_processes: Optional[int] = None
-    propagator: str = "PYOORB"
-    parallel_backend: Literal["cf"] = "cf"
+    propagator: Literal["PYOORB"] = "PYOORB"
     cell_radius: float = 10
     vx_min: float = -0.1
     vx_max: float = 0.1

--- a/thor/main.py
+++ b/thor/main.py
@@ -47,7 +47,9 @@ def initialize_test_orbit(
     Initialize the test orbit by saving it to disk if a working directory is provided.
     """
     if working_dir is not None:
-        test_orbit_directory = pathlib.Path(working_dir, "inputs", test_orbit.orbit_id)
+        test_orbit_directory = pathlib.Path(
+            working_dir, "inputs", test_orbit.orbit_id[0].as_py()
+        )
         test_orbit_directory.mkdir(parents=True, exist_ok=True)
         test_orbit_path = os.path.join(test_orbit_directory, "test_orbit.parquet")
         test_orbit.to_parquet(test_orbit_path)
@@ -113,7 +115,7 @@ def link_test_orbit(
     if working_dir is not None:
         working_dir_path = pathlib.Path(working_dir)
         logger.info(f"Using working directory: {working_dir}")
-        test_orbit_directory = pathlib.Path(working_dir_path, test_orbit.orbit_id)
+        test_orbit_directory = pathlib.Path(working_dir, test_orbit.orbit_id[0].as_py())
         test_orbit_directory.mkdir(parents=True, exist_ok=True)
         inputs_dir = pathlib.Path(working_dir_path, "inputs")
         inputs_dir.mkdir(parents=True, exist_ok=True)

--- a/thor/main.py
+++ b/thor/main.py
@@ -104,9 +104,9 @@ def load_initial_checkpoint_values(
     filtered_observations = qv.defragment(filtered_observations)
     filtered_observations = filtered_observations.sort_by(
         [
-            "detections.time.days",
-            "detections.time.nanos",
-            "observatory_code",
+            "coordinates.time.days",
+            "coordinates.time.nanos",
+            "coordinates.origin.code",
         ]
     )
 

--- a/thor/main.py
+++ b/thor/main.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import time
 from dataclasses import dataclass
-from typing import Any, Iterable, Iterator, List, Literal, Optional
+from typing import Iterable, Iterator, List, Literal, Optional, Tuple
 
 import quivr as qv
 import ray
@@ -24,6 +24,16 @@ from .range_and_transform import TransformedDetections, range_and_transform
 
 logger = logging.getLogger("thor")
 
+VALID_STAGES = Literal[
+    "filter_observations",
+    "range_and_transform",
+    "cluster_and_link",
+    "initial_orbit_determination",
+    "differential_correction",
+    "recover_orbits",
+    "complete",
+]
+
 
 def initialize_use_ray(config: Config) -> bool:
     use_ray = False
@@ -41,25 +51,17 @@ def initialize_use_ray(config: Config) -> bool:
 
 @dataclass
 class CheckpointData:
-    stage: Literal[
-        "filter_observations",
-        "range_and_transform",
-        "cluster_and_link",
-        "initial_orbit_determination",
-        "differential_correction",
-        "recover_orbits",
-        "complete",
-    ]
-    filtered_observations: Optional[Observations] = None
-    transformed_detections: Optional[TransformedDetections] = None
-    clusters: Optional[Clusters] = None
-    cluster_members: Optional[ClusterMembers] = None
-    iod_orbits: Optional[FittedOrbits] = None
-    iod_orbit_members: Optional[FittedOrbitMembers] = None
-    od_orbits: Optional[FittedOrbits] = None
-    od_orbit_members: Optional[FittedOrbitMembers] = None
-    recovered_orbits: Optional[FittedOrbits] = None
-    recovered_orbit_members: Optional[FittedOrbitMembers] = None
+    stage: VALID_STAGES
+    filtered_observations: Observations = Observations.empty()
+    transformed_detections: TransformedDetections = TransformedDetections.empty()
+    clusters: Clusters = Clusters.empty()
+    cluster_members: ClusterMembers = ClusterMembers.empty()
+    iod_orbits: FittedOrbits = FittedOrbits.empty()
+    iod_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
+    od_orbits: FittedOrbits = FittedOrbits.empty()
+    od_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
+    recovered_orbits: FittedOrbits = FittedOrbits.empty()
+    recovered_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
 
 
 def initialize_test_orbit(
@@ -84,7 +86,7 @@ def load_initial_checkpoint_values(
 
     We want to avoid loading objects into memory that are not required.
     """
-    stage = "filter_observations"
+    stage: VALID_STAGES = "filter_observations"
     # Without a checkpoint directory, we always start at the beginning
     if test_orbit_directory is None:
         return CheckpointData(stage=stage)
@@ -243,8 +245,8 @@ class LinkTestOrbitStageResult:
         "differential_correction",
         "recover_orbits",
     ]
-    result: Iterable[Any]
-    path: Optional[Iterable[str]] = None
+    result: Iterable[qv.AnyTable]
+    path: Tuple[Optional[str], ...] = (None,)
 
 
 def link_test_orbit(
@@ -287,11 +289,11 @@ def link_test_orbit(
 
     test_orbit_directory = None
     if working_dir is not None:
-        working_dir = pathlib.Path(working_dir)
+        working_dir_path = pathlib.Path(working_dir)
         logger.info(f"Using working directory: {working_dir}")
-        test_orbit_directory = pathlib.Path(working_dir, test_orbit.orbit_id)
+        test_orbit_directory = pathlib.Path(working_dir_path, test_orbit.orbit_id)
         test_orbit_directory.mkdir(parents=True, exist_ok=True)
-        inputs_dir = pathlib.Path(working_dir, "inputs")
+        inputs_dir = pathlib.Path(working_dir_path, "inputs")
         inputs_dir.mkdir(parents=True, exist_ok=True)
 
     initialize_test_orbit(test_orbit, working_dir)
@@ -320,7 +322,7 @@ def link_test_orbit(
 
     if checkpoint.stage == "complete":
         logger.info("Found recovered orbits in checkpoint, exiting early...")
-        path = None
+        path: Tuple[Optional[str], ...] = (None,)
         if test_orbit_directory:
             path = (
                 os.path.join(test_orbit_directory, "recovered_orbits.parquet"),

--- a/thor/main.py
+++ b/thor/main.py
@@ -9,30 +9,20 @@ import quivr as qv
 import ray
 from adam_core.propagator import PYOORB
 
-from .clusters import ClusterMembers, Clusters, cluster_and_link
+from .checkpointing import create_checkpoint_data, load_initial_checkpoint_values
+from .clusters import cluster_and_link
 from .config import Config, initialize_config
 from .observations.filters import ObservationFilter, filter_observations
 from .observations.observations import Observations
 from .orbit import TestOrbits
-from .orbit_determination.fitted_orbits import FittedOrbitMembers, FittedOrbits
 from .orbits import (
     differential_correction,
     initial_orbit_determination,
     merge_and_extend_orbits,
 )
-from .range_and_transform import TransformedDetections, range_and_transform
+from .range_and_transform import range_and_transform
 
 logger = logging.getLogger("thor")
-
-VALID_STAGES = Literal[
-    "filter_observations",
-    "range_and_transform",
-    "cluster_and_link",
-    "initial_orbit_determination",
-    "differential_correction",
-    "recover_orbits",
-    "complete",
-]
 
 
 def initialize_use_ray(config: Config) -> bool:
@@ -49,21 +39,6 @@ def initialize_use_ray(config: Config) -> bool:
     return use_ray
 
 
-@dataclass
-class CheckpointData:
-    stage: VALID_STAGES
-    filtered_observations: Observations = Observations.empty()
-    transformed_detections: TransformedDetections = TransformedDetections.empty()
-    clusters: Clusters = Clusters.empty()
-    cluster_members: ClusterMembers = ClusterMembers.empty()
-    iod_orbits: FittedOrbits = FittedOrbits.empty()
-    iod_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
-    od_orbits: FittedOrbits = FittedOrbits.empty()
-    od_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
-    recovered_orbits: FittedOrbits = FittedOrbits.empty()
-    recovered_orbit_members: FittedOrbitMembers = FittedOrbitMembers.empty()
-
-
 def initialize_test_orbit(
     test_orbit: TestOrbits,
     working_dir: Optional[str] = None,
@@ -76,159 +51,6 @@ def initialize_test_orbit(
         test_orbit_directory.mkdir(parents=True, exist_ok=True)
         test_orbit_path = os.path.join(test_orbit_directory, "test_orbit.parquet")
         test_orbit.to_parquet(test_orbit_path)
-
-
-def load_initial_checkpoint_values(
-    test_orbit_directory: Optional[pathlib.Path] = None,
-) -> CheckpointData:
-    """
-    Check for completed stages and return values from disk if they exist.
-
-    We want to avoid loading objects into memory that are not required.
-    """
-    stage: VALID_STAGES = "filter_observations"
-    # Without a checkpoint directory, we always start at the beginning
-    if test_orbit_directory is None:
-        return CheckpointData(stage=stage)
-
-    # filtered_observations is always needed when it exists
-    filtered_observations_path = pathlib.Path(
-        test_orbit_directory, "filtered_observations.parquet"
-    )
-    # If it doesn't exist, start at the beginning.
-    if not filtered_observations_path.exists():
-        return CheckpointData(stage=stage)
-    logger.info("Found filtered observations")
-    filtered_observations = Observations.from_parquet(filtered_observations_path)
-
-    # Unfortunately we have to reinitialize the times to set the attribute
-    # correctly.
-    filtered_observations = qv.defragment(filtered_observations)
-    filtered_observations = filtered_observations.sort_by(
-        [
-            "coordinates.time.days",
-            "coordinates.time.nanos",
-            "coordinates.origin.code",
-        ]
-    )
-
-    # If the pipeline was started but we have recovered_orbits already, we
-    # are done and should exit early.
-    recovered_orbits_path = pathlib.Path(
-        test_orbit_directory, "recovered_orbits.parquet"
-    )
-    recovered_orbit_members_path = pathlib.Path(
-        test_orbit_directory, "recovered_orbit_members.parquet"
-    )
-    if recovered_orbits_path.exists() and recovered_orbit_members_path.exists():
-        logger.info("Found recovered orbits in checkpoint")
-        recovered_orbits = FittedOrbits.from_parquet(recovered_orbits_path)
-        recovered_orbit_members = FittedOrbitMembers.from_parquet(
-            recovered_orbit_members_path
-        )
-
-        # Unfortunately we have to reinitialize the times to set the attribute
-        # correctly.
-        recovered_orbits = qv.defragment(recovered_orbits)
-        recovered_orbits = recovered_orbits.sort_by(
-            [
-                "coordinates.time.days",
-                "coordinates.time.nanos",
-            ]
-        )
-
-        return CheckpointData(
-            stage="complete",
-            recovered_orbits=recovered_orbits,
-            recovered_orbit_members=recovered_orbit_members,
-        )
-
-    # Now with filtered_observations available, we can check for the later
-    # stages in reverse order.
-    od_orbits_path = pathlib.Path(test_orbit_directory, "od_orbits.parquet")
-    od_orbit_members_path = pathlib.Path(
-        test_orbit_directory, "od_orbit_members.parquet"
-    )
-    if od_orbits_path.exists() and od_orbit_members_path.exists():
-        logger.info("Found OD orbits in checkpoint")
-        od_orbits = FittedOrbits.from_parquet(od_orbits_path)
-        od_orbit_members = FittedOrbitMembers.from_parquet(od_orbit_members_path)
-
-        # Unfortunately we have to reinitialize the times to set the attribute
-        # correctly.
-        od_orbits = qv.defragment(od_orbits)
-        od_orbits = od_orbits.sort_by(
-            [
-                "coordinates.time.days",
-                "coordinates.time.nanos",
-            ]
-        )
-
-        return CheckpointData(
-            stage="recover_orbits",
-            filtered_observations=filtered_observations,
-            od_orbits=od_orbits,
-            od_orbit_members=od_orbit_members,
-        )
-
-    iod_orbits_path = pathlib.Path(test_orbit_directory, "iod_orbits.parquet")
-    iod_orbit_members_path = pathlib.Path(
-        test_orbit_directory, "iod_orbit_members.parquet"
-    )
-    if iod_orbits_path.exists() and iod_orbit_members_path.exists():
-        logger.info("Found IOD orbits")
-        iod_orbits = FittedOrbits.from_parquet(iod_orbits_path)
-        iod_orbit_members = FittedOrbitMembers.from_parquet(iod_orbit_members_path)
-
-        # Unfortunately we have to reinitialize the times to set the attribute
-        # correctly.
-        iod_orbits = qv.defragment(iod_orbits)
-        iod_orbits = iod_orbits.sort_by(
-            [
-                "coordinates.time.days",
-                "coordinates.time.nanos",
-            ]
-        )
-
-        return CheckpointData(
-            stage="differential_correction",
-            filtered_observations=filtered_observations,
-            iod_orbits=iod_orbits,
-            iod_orbit_members=iod_orbit_members,
-        )
-
-    clusters_path = pathlib.Path(test_orbit_directory, "clusters.parquet")
-    cluster_members_path = pathlib.Path(test_orbit_directory, "cluster_members.parquet")
-    if clusters_path.exists() and cluster_members_path.exists():
-        logger.info("Found clusters")
-        clusters = Clusters.from_parquet(clusters_path)
-        cluster_members = ClusterMembers.from_parquet(cluster_members_path)
-
-        return CheckpointData(
-            stage="initial_orbit_determination",
-            filtered_observations=filtered_observations,
-            clusters=clusters,
-            cluster_members=cluster_members,
-        )
-
-    transformed_detections_path = pathlib.Path(
-        test_orbit_directory, "transformed_detections.parquet"
-    )
-    if transformed_detections_path.exists():
-        logger.info("Found transformed detections")
-        transformed_detections = TransformedDetections.from_parquet(
-            transformed_detections_path
-        )
-
-        return CheckpointData(
-            stage="cluster_and_link",
-            filtered_observations=filtered_observations,
-            transformed_detections=transformed_detections,
-        )
-
-    return CheckpointData(
-        stage="range_and_transform", filtered_observations=filtered_observations
-    )
 
 
 @dataclass
@@ -352,8 +174,8 @@ def link_test_orbit(
             path=(filtered_observations_path,),
         )
 
-        checkpoint = CheckpointData(
-            stage="range_and_transform",
+        checkpoint = create_checkpoint_data(
+            "range_and_transform",
             filtered_observations=filtered_observations,
         )
 
@@ -387,8 +209,8 @@ def link_test_orbit(
             path=(transformed_detections_path,),
         )
 
-        checkpoint = CheckpointData(
-            stage="cluster_and_link",
+        checkpoint = create_checkpoint_data(
+            "cluster_and_link",
             filtered_observations=filtered_observations,
             transformed_detections=transformed_detections,
         )
@@ -434,8 +256,8 @@ def link_test_orbit(
             path=(clusters_path, cluster_members_path),
         )
 
-        checkpoint = CheckpointData(
-            stage="initial_orbit_determination",
+        checkpoint = create_checkpoint_data(
+            "initial_orbit_determination",
             filtered_observations=filtered_observations,
             clusters=clusters,
             cluster_members=cluster_members,
@@ -482,8 +304,8 @@ def link_test_orbit(
             path=(iod_orbits_path, iod_orbit_members_path),
         )
 
-        checkpoint = CheckpointData(
-            stage="differential_correction",
+        checkpoint = create_checkpoint_data(
+            "differential_correction",
             filtered_observations=filtered_observations,
             iod_orbits=iod_orbits,
             iod_orbit_members=iod_orbit_members,
@@ -530,8 +352,8 @@ def link_test_orbit(
             path=(od_orbits_path, od_orbit_members_path),
         )
 
-        checkpoint = CheckpointData(
-            stage="recover_orbits",
+        checkpoint = create_checkpoint_data(
+            "recover_orbits",
             filtered_observations=filtered_observations,
             od_orbits=od_orbits,
             od_orbit_members=od_orbit_members,

--- a/thor/observations/__init__.py
+++ b/thor/observations/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from .observations import Observations
+from .photometry import Photometry

--- a/thor/observations/__init__.py
+++ b/thor/observations/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa: F401
-from .observations import Observations
-from .photometry import Photometry
+from .observations import *
+from .photometry import *

--- a/thor/observations/filters.py
+++ b/thor/observations/filters.py
@@ -314,7 +314,11 @@ def filter_observations(
     if len(filtered_observations) > 0:
         filtered_observations = qv.defragment(filtered_observations)
         filtered_observations = filtered_observations.sort_by(
-            ["coordinates.time.days", "coordinates.time.nanos", "coordinates.origin.code"]
+            [
+                "coordinates.time.days",
+                "coordinates.time.nanos",
+                "coordinates.origin.code",
+            ]
         )
 
     time_end = time.perf_counter()

--- a/thor/observations/observations.py
+++ b/thor/observations/observations.py
@@ -10,6 +10,12 @@ from adam_core.observers import Observers
 from adam_core.time import Timestamp
 
 from .photometry import Photometry
+from .states import calculate_state_ids
+
+__all__ = [
+    "InputObservations",
+    "Observations",
+]
 
 
 class ObserversWithStates(qv.Table):
@@ -17,24 +23,92 @@ class ObserversWithStates(qv.Table):
     observers = Observers.as_column()
 
 
+class InputObservations(qv.Table):
+    id = qv.StringColumn()
+    exposure_id = qv.StringColumn()
+    time = Timestamp.as_column()
+    ra = qv.Float64Column()
+    dec = qv.Float64Column()
+    ra_sigma = qv.Float64Column(nullable=True)
+    dec_sigma = qv.Float64Column(nullable=True)
+    ra_dec_cov = qv.Float64Column(nullable=True)
+    mag = qv.Float64Column()
+    mag_sigma = qv.Float64Column(nullable=True)
+    filter = qv.StringColumn()
+    observatory_code = qv.StringColumn()
+
+
 class Observations(qv.Table):
-    """
-    The Observations table stored invidual point source detections and a state ID for each unique
-    combination of detection time and observatory code. The state ID is used as reference to a specific
-    observing geometry.
-
-    The recommended constructor to use is `~Observations.from_detections_and_exposures`, as this function
-    will sort the detections by time and observatory code, and for each unique combination of the two
-    assign a unique state ID. If not using this constructor, please ensure that the detections are sorted
-    by time and observatory code and that each unique combination of time and observatory code has a unique
-    state ID.
-    """
-
     id = qv.StringColumn()
     exposure_id = qv.StringColumn()
     coordinates = SphericalCoordinates.as_column()
     photometry = Photometry.as_column()
     state_id = qv.Int64Column()
+
+    @classmethod
+    def from_input_observations(cls, observations: InputObservations) -> "Observations":
+        """
+        Create a THOR observations table from an InputObservations table. The InputObservations table
+        are sorted by ascending time and observatory code.
+
+        Parameters
+        ----------
+        observations : `~InputObservations`
+            A table of input observations.
+
+        Returns
+        -------
+        observations : `~Observations`
+            A table of THOR observations.
+        """
+        # Sort the observations by time and observatory code
+        observations_sorted = observations.sort_by(
+            ["time.days", "time.nanos", "observatory_code"]
+        )
+
+        # If the times are not in UTC, convert them to UTC
+        if observations_sorted.time.scale != "utc":
+            observations_sorted = observations_sorted.set_column(
+                "time", observations_sorted.time.rescale("utc")
+            )
+
+        # Extract the sigma and covariance values for RA and Dec
+        ra_sigma = observations_sorted.ra_sigma.to_numpy(zero_copy_only=False)
+        dec_sigma = observations_sorted.dec_sigma.to_numpy(zero_copy_only=False)
+        ra_dec_cov = observations_sorted.ra_dec_cov.to_numpy(zero_copy_only=False)
+
+        # Create the covariance matrices
+        covariance_matrices = np.full((len(observations_sorted), 6, 6), np.nan)
+        covariance_matrices[:, 1, 1] = ra_sigma**2
+        covariance_matrices[:, 2, 2] = dec_sigma**2
+        covariance_matrices[:, 1, 2] = ra_dec_cov
+        covariance_matrices[:, 2, 1] = ra_dec_cov
+        covariances = CoordinateCovariances.from_matrix(covariance_matrices)
+
+        # Create the coordinates table
+        coords = SphericalCoordinates.from_kwargs(
+            lon=observations_sorted.ra,
+            lat=observations_sorted.dec,
+            time=observations_sorted.time,
+            covariance=covariances,
+            origin=Origin.from_kwargs(code=observations_sorted.observatory_code),
+            frame="equatorial",
+        )
+
+        # Create the photometry table
+        photometry = Photometry.from_kwargs(
+            filter=observations_sorted.filter,
+            mag=observations_sorted.mag,
+            mag_sigma=observations_sorted.mag_sigma,
+        )
+
+        return cls.from_kwargs(
+            id=observations_sorted.id,
+            exposure_id=observations_sorted.exposure_id,
+            coordinates=coords,
+            photometry=photometry,
+            state_id=calculate_state_ids(coords),
+        )
 
     @classmethod
     def from_detections_and_exposures(
@@ -60,111 +134,59 @@ class Observations(qv.Table):
         # TODO: One thing we could try in the future is truncating observation times to ~1ms and using those to group
         # into indvidual states (i.e. if two observations are within 1ms of each other, they are in the same state). Again,
         # this only matters for those detections that have times that differ from the midpoint time of the exposure (LSST)
-
         # If the detection times are not in UTC, convert them to UTC
         if detections.time.scale != "utc":
             detections = detections.set_column("time", detections.time.rescale("utc"))
 
-        # Flatten the detections table (i.e. remove the nested columns). Unfortunately joins on tables
-        # with nested columns are not all supported in pyarrow
-        detections_flattened = pa.table(
-            [
-                detections.id,
-                detections.exposure_id,
-                detections.time.days,
-                detections.time.nanos,
-                detections.ra,
-                detections.ra_sigma,
-                detections.dec,
-                detections.dec_sigma,
-                detections.mag,
-                detections.mag_sigma,
-            ],
-            names=[
-                "id",
-                "exposure_id",
-                "days",
-                "nanos",
-                "ra",
-                "ra_sigma",
-                "dec",
-                "dec_sigma",
-                "mag",
-                "mag_sigma",
-            ],
+        # Join the detections and exposures tables
+        detections_flattened = detections.flattened_table()
+        exposures_flattened = exposures.flattened_table()
+        detections_exposures = detections_flattened.join(
+            exposures_flattened, ["exposure_id"], right_keys=["id"]
         )
 
-        # Extract the exposure IDs and the observatory codes from the exposures table
-        exposure_filters_obscodes = pa.table(
-            [exposures.id, exposures.filter, exposures.observatory_code],
-            names=["exposure_id", "filter", "observatory_code"],
+        # Combine chunks of joined table
+        detections_exposures = detections_exposures.combine_chunks()
+
+        # Create covariance matrices
+        sigmas = np.zeros((len(detections_exposures), 6))
+        sigmas[:, 1] = detections_exposures["ra_sigma"].to_numpy(zero_copy_only=False)
+        sigmas[:, 2] = detections_exposures["dec_sigma"].to_numpy(zero_copy_only=False)
+        covariances = CoordinateCovariances.from_sigmas(sigmas)
+
+        # Create the coordinates table
+        coordinates = SphericalCoordinates.from_kwargs(
+            lon=detections_exposures["ra"],
+            lat=detections_exposures["dec"],
+            time=Timestamp.from_kwargs(
+                days=detections_exposures["time.days"],
+                nanos=detections_exposures["time.nanos"],
+                scale="utc",
+            ),
+            covariance=covariances,
+            origin=Origin.from_kwargs(code=detections_exposures["observatory_code"]),
+            frame="equatorial",
         )
 
-        # Join the detection times and the exposure IDs so that each detection has an observatory code
-        obscode_times = detections_flattened.join(
-            exposure_filters_obscodes, ["exposure_id"]
-        )
-
-        # Group the detections by the observatory code and the detection times and then grab the unique ones
-        unique_obscode_times = obscode_times.group_by(
-            ["days", "nanos", "observatory_code"]
-        ).aggregate([])
-
-        # Now sort the unique detections by the observatory code and the detection time
-        unique_obscode_times = unique_obscode_times.sort_by(
-            [
-                ("days", "ascending"),
-                ("nanos", "ascending"),
-                ("observatory_code", "ascending"),
-            ]
-        )
-
-        # For each unique detection time and observatory code assign a unique state ID
-        unique_obscode_times = unique_obscode_times.add_column(
-            0,
-            pa.field("state_id", pa.int64()),
-            pa.array(np.arange(0, len(unique_obscode_times))),
-        )
-
-        # Join the unique observatory code and detections back to the original detections
-        detections_with_states = obscode_times.join(
-            unique_obscode_times, ["days", "nanos", "observatory_code"]
-        )
-
-        # Now sort the detections one final time by state ID
-        detections_with_states = detections_with_states.sort_by(
-            [("state_id", "ascending")]
-        )
-
-        sigmas = np.zeros((len(detections_with_states), 6))
-        sigmas[:, 1] = detections_with_states["ra_sigma"].to_numpy(zero_copy_only=False)
-        sigmas[:, 2] = detections_with_states["dec_sigma"].to_numpy(
-            zero_copy_only=False
+        # Create the photometry table
+        photometry = Photometry.from_kwargs(
+            filter=detections_exposures["filter"],
+            mag=detections_exposures["mag"],
+            mag_sigma=detections_exposures["mag_sigma"],
         )
 
         return cls.from_kwargs(
-            id=detections_with_states["id"],
-            exposure_id=detections_with_states["exposure_id"],
-            coordinates=SphericalCoordinates.from_kwargs(
-                lon=detections_with_states["ra"],
-                lat=detections_with_states["dec"],
-                time=Timestamp.from_kwargs(
-                    days=detections_with_states["days"],
-                    nanos=detections_with_states["nanos"],
-                    scale="utc",
-                ),
-                covariance=CoordinateCovariances.from_sigmas(sigmas),
-                origin=Origin.from_kwargs(
-                    code=detections_with_states["observatory_code"]
-                ),
-                frame="equatorial",
-            ),
-            photometry=Photometry.from_kwargs(
-                filter=detections_with_states["filter"],
-                mag=detections_with_states["mag"],
-                mag_sigma=detections_with_states["mag_sigma"],
-            ),
-            state_id=detections_with_states["state_id"],
+            id=detections_exposures["id"],
+            exposure_id=detections_exposures["exposure_id"],
+            coordinates=coordinates,
+            photometry=photometry,
+            state_id=calculate_state_ids(coordinates),
+        ).sort_by(
+            [
+                "coordinates.time.days",
+                "coordinates.time.nanos",
+                "coordinates.origin.code",
+            ]
         )
 
     def get_observers(self) -> ObserversWithStates:

--- a/thor/observations/photometry.py
+++ b/thor/observations/photometry.py
@@ -1,0 +1,8 @@
+import quivr as qv
+
+
+class Photometry(qv.Table):
+
+    mag = qv.Float64Column()
+    mag_sigma = qv.Float64Column(nullable=True)
+    filter = qv.StringColumn()

--- a/thor/observations/photometry.py
+++ b/thor/observations/photometry.py
@@ -1,5 +1,7 @@
 import quivr as qv
 
+__all__ = ["Photometry"]
+
 
 class Photometry(qv.Table):
 

--- a/thor/observations/states.py
+++ b/thor/observations/states.py
@@ -1,0 +1,68 @@
+from typing import Union
+
+import numpy as np
+import pyarrow as pa
+from adam_core.coordinates import CartesianCoordinates, SphericalCoordinates
+
+
+def calculate_state_ids(
+    coordinates: Union[SphericalCoordinates, CartesianCoordinates]
+) -> pa.Int64Array:
+    """
+    Calculate the state IDs for a set of coordinates. States are defined as unique time and origin
+    combinations. This function will return a state ID for each coordinate in the input coordinates
+    array. State IDs are computed in asencding order of time and origin code.
+
+    Parameters
+    ----------
+    coordinates
+        The coordinates for which to calculate the state IDs.
+
+    Returns
+    -------
+    state_ids
+        The state IDs for each coordinate in the input coordinates array.
+    """
+    # Extract the time and origin columns
+    table = coordinates.flattened_table()
+
+    # Append index column so we can maintain the original order
+    table = table.append_column(
+        pa.field("index", pa.int64()),
+        pa.array(np.arange(0, len(table)))
+    )
+
+    # Select only the relevant columns
+    time_origins = table.select(["time.days", "time.nanos", "origin.code"])
+
+    # Group the detections by the observatory code and the detection times and then grab the unique ones
+    unique_time_origins = time_origins.group_by(
+        ["time.days", "time.nanos", "origin.code"]
+    ).aggregate([])
+
+    # Now sort the unique states by the time and origin code
+    unique_time_origins = unique_time_origins.sort_by(
+        [
+            ("time.days", "ascending"),
+            ("time.nanos", "ascending"),
+            ("origin.code", "ascending"),
+        ]
+    )
+
+    # For each unique state assign a unique state ID
+    unique_time_origins = unique_time_origins.append_column(
+        pa.field("state_id", pa.int64()),
+        pa.array(np.arange(0, len(unique_time_origins))),
+    )
+
+    # Drop the covariance values since ListColumns cannot be joined
+    table = table.drop(["covariance.values"])
+
+    # Join the states back to the original coordinates and sort by the original index
+    coordinates_with_states = table.join(
+        unique_time_origins, ["time.days", "time.nanos", "origin.code"]
+    ).sort_by([("index", "ascending")])
+
+
+    # Now return the state IDs
+    return coordinates_with_states.column("state_id").combine_chunks()

--- a/thor/observations/states.py
+++ b/thor/observations/states.py
@@ -28,8 +28,7 @@ def calculate_state_ids(
 
     # Append index column so we can maintain the original order
     table = table.append_column(
-        pa.field("index", pa.int64()),
-        pa.array(np.arange(0, len(table)))
+        pa.field("index", pa.int64()), pa.array(np.arange(0, len(table)))
     )
 
     # Select only the relevant columns
@@ -62,7 +61,6 @@ def calculate_state_ids(
     coordinates_with_states = table.join(
         unique_time_origins, ["time.days", "time.nanos", "origin.code"]
     ).sort_by([("index", "ascending")])
-
 
     # Now return the state IDs
     return coordinates_with_states.column("state_id").combine_chunks()

--- a/thor/observations/tests/test_filters.py
+++ b/thor/observations/tests/test_filters.py
@@ -114,8 +114,8 @@ def fixed_observations(
 
 def test_observation_fixtures(fixed_test_orbit, fixed_observations):
     assert len(fixed_test_orbit) == 1
-    assert len(pc.unique(fixed_observations.detections.exposure_id)) == 5
-    assert len(fixed_observations.detections) == 100 * 100 * 5
+    assert len(pc.unique(fixed_observations.exposure_id)) == 5
+    assert len(fixed_observations.coordinates) == 100 * 100 * 5
 
 
 def test_orbit_radius_observation_filter(fixed_test_orbit, fixed_observations):
@@ -123,16 +123,16 @@ def test_orbit_radius_observation_filter(fixed_test_orbit, fixed_observations):
         radius=0.5,
     )
     have = fos.apply(fixed_observations, fixed_test_orbit)
-    assert len(pc.unique(have.detections.exposure_id)) == 5
+    assert len(pc.unique(have.exposure_id)) == 5
     assert pc.all(
         pc.equal(
-            pc.unique(have.detections.exposure_id),
-            pc.unique(fixed_observations.detections.exposure_id),
+            pc.unique(have.exposure_id),
+            pc.unique(fixed_observations.exposure_id),
         )
     )
     # Should be about pi/4 fraction of the detections (0.785
-    assert len(have.detections) < 0.80 * len(fixed_observations.detections)
-    assert len(have.detections) > 0.76 * len(fixed_observations.detections)
+    assert len(have.coordinates) < 0.80 * len(fixed_observations.coordinates)
+    assert len(have.coordinates) > 0.76 * len(fixed_observations.coordinates)
 
 
 def test_filter_observations(fixed_observations, fixed_test_orbit):
@@ -141,9 +141,9 @@ def test_filter_observations(fixed_observations, fixed_test_orbit):
     config = Config(cell_radius=0.5)
 
     have = filter_observations(fixed_observations, fixed_test_orbit, config)
-    assert len(pc.unique(have.detections.exposure_id)) == 5
-    assert len(have.detections) < 0.80 * len(fixed_observations.detections)
-    assert len(have.detections) > 0.76 * len(fixed_observations.detections)
+    assert len(pc.unique(have.exposure_id)) == 5
+    assert len(have.coordinates) < 0.80 * len(fixed_observations.coordinates)
+    assert len(have.coordinates) > 0.76 * len(fixed_observations.coordinates)
 
     # Make sure if we pass a custom list of filters, they are used
     # instead
@@ -154,7 +154,7 @@ def test_filter_observations(fixed_observations, fixed_test_orbit):
     have = filter_observations(
         fixed_observations, fixed_test_orbit, config, filters=filters
     )
-    assert len(have.detections) == len(fixed_observations.detections)
+    assert len(have.coordinates) == len(fixed_observations.coordinates)
 
     # Ensure NOOPFilter.apply was run
     filters[0].apply.assert_called_once()

--- a/thor/observations/tests/test_filters.py
+++ b/thor/observations/tests/test_filters.py
@@ -138,7 +138,7 @@ def test_orbit_radius_observation_filter(fixed_test_orbit, fixed_observations):
 def test_filter_observations(fixed_observations, fixed_test_orbit):
     # Test that if not filters are passed, we use
     # TestOrbitRadiusObservationFilter by defualt
-    config = Config(cell_radius=0.5)
+    config = Config(cell_radius=0.5, max_processes=1)
 
     have = filter_observations(fixed_observations, fixed_test_orbit, config)
     assert len(pc.unique(have.exposure_id)) == 5

--- a/thor/observations/tests/test_states.py
+++ b/thor/observations/tests/test_states.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+from adam_core.coordinates import CartesianCoordinates, Origin, SphericalCoordinates
+from adam_core.time import Timestamp
+
+from ..states import calculate_state_ids
+
+
+def test_calculate_state_ids():
+    # Create some coordinates with different times and origins and make sure
+    # that the state IDs are assigned correctly
+    origins = Origin.from_kwargs(code=["500", "500", "I41", "500", "500", "I41"])
+    times = Timestamp.from_mjd(
+        [59002.1, 59001.1, 59001.1, 59001.1, 59002.1, 59002.1],
+        scale="utc",
+    )
+    coords = SphericalCoordinates.from_kwargs(
+        rho=np.random.rand(6),
+        lon=np.random.rand(6),
+        lat=np.random.rand(6),
+        time=times,
+        origin=origins,
+        frame="equatorial",
+    )
+
+    state_ids = calculate_state_ids(coords)
+    expected_state_ids = pa.array([2, 0, 1, 0, 2, 3])
+
+    assert pc.all(pc.equal(state_ids, expected_state_ids)).as_py()

--- a/thor/orbit.py
+++ b/thor/orbit.py
@@ -138,7 +138,7 @@ class TestOrbits(qv.Table):
             and getattr(self, "_cached_observation_ids", None) is None
         ):
             self._cached_ephemeris: Optional[TestOrbitEphemeris] = None
-            self._cached_observation_ids: Optional[TestOrbitEphemeris] = None
+            self._cached_observation_ids: Optional[pa.Array] = None
             return False
         elif (
             getattr(self, "_cached_ephemeris", None) is not None
@@ -146,7 +146,7 @@ class TestOrbits(qv.Table):
             and pc.all(
                 pc.is_in(
                     observations.id.sort(),
-                    self._cached_observation_ids.sort(),
+                    self._cached_observation_ids.sort(),  # type: ignore
                 )
             ).as_py()
         ):

--- a/thor/orbits/attribution.py
+++ b/thor/orbits/attribution.py
@@ -118,7 +118,7 @@ def attribution_worker(
 
     # Select the orbits and observations for this batch
     observations = observations.take(observation_indices)
-    orbits = orbits.apply_mask(pc.equal(orbits.orbit_id, orbit_ids))
+    orbits = orbits.apply_mask(pc.is_in(orbits.orbit_id, orbit_ids))
 
     # Get the unique observers for this batch of observations
     observers_with_states = observations.get_observers()

--- a/thor/orbits/attribution.py
+++ b/thor/orbits/attribution.py
@@ -59,7 +59,7 @@ class Attributions(qv.Table):
         # Filter the observations to only include those that have been attributed
         # to an orbit
         observations_filtered = observations.apply_mask(
-            pc.is_in(observations.detections.id, flattened_table.column("obs_id"))
+            pc.is_in(observations.id, flattened_table.column("obs_id"))
         )
 
         # Flatten the observations table
@@ -67,12 +67,12 @@ class Attributions(qv.Table):
 
         # Only keep relevant columns
         flattened_observations = flattened_observations.select(
-            ["detections.id", "detections.time.days", "detections.time.nanos"]
+            ["id", "coordinates.time.days", "coordinates.time.nanos"]
         )
 
         # Join the time column back to the flattened attributions table
         flattened_table = flattened_table.join(
-            flattened_observations, ["obs_id"], right_keys=["detections.id"]
+            flattened_observations, ["obs_id"], right_keys=["id"]
         )
 
         # Add index column
@@ -84,15 +84,15 @@ class Attributions(qv.Table):
         flattened_table = flattened_table.sort_by(
             [
                 ("orbit_id", "ascending"),
-                ("detections.time.days", "ascending"),
-                ("detections.time.nanos", "ascending"),
+                ("coordinates.time.days", "ascending"),
+                ("coordinates.time.nanos", "ascending"),
             ]
         )
 
         # Group by orbit ID and observation time
         indices = (
             flattened_table.group_by(
-                ["orbit_id", "detections.time.days", "detections.time.nanos"],
+                ["orbit_id", "coordinates.time.days", "coordinates.time.nanos"],
                 use_threads=False,
             )
             .aggregate([("index", "first")])
@@ -134,7 +134,7 @@ def attribution_worker(
         "coordinates.time", ephemeris.coordinates.time.rounded(precision="ms")
     )
     observations_rounded = observations.set_column(
-        "detections.time", observations.detections.time.rounded(precision="ms")
+        "coordinates.time", observations.coordinates.time.rounded(precision="ms")
     )
 
     # Create a linkage between the ephemeris and observations
@@ -147,9 +147,9 @@ def attribution_worker(
             "code": ephemeris.coordinates.origin.code,
         },
         right_keys={
-            "days": observations_rounded.detections.time.days,
-            "nanos": observations_rounded.detections.time.nanos,
-            "code": observations_rounded.observatory_code,
+            "days": observations_rounded.coordinates.time.days,
+            "nanos": observations_rounded.coordinates.time.nanos,
+            "code": observations_rounded.coordinates.origin.code,
         },
     )
 
@@ -164,13 +164,13 @@ def attribution_worker(
     for _, ephemeris_i, observations_i in linkage.iterate():
 
         # Extract the observation IDs and times
-        obs_ids = observations_i.detections.id.to_numpy(zero_copy_only=False)
-        obs_times = observations_i.detections.time.mjd().to_numpy(zero_copy_only=False)
+        obs_ids = observations_i.id.to_numpy(zero_copy_only=False)
+        obs_times = observations_i.coordinates.time.mjd().to_numpy(zero_copy_only=False)
         orbit_ids = ephemeris_i.orbit_id.to_numpy(zero_copy_only=False)
 
         # Extract the spherical coordinates for both the observations
         # and ephemeris
-        coords = observations_i.to_spherical_coordinates()
+        coords = observations_i.coordinates
         coords_predicted = ephemeris_i.coordinates
 
         # Haversine metric requires latitude first then longitude...
@@ -449,7 +449,7 @@ def merge_and_extend_orbits(
             observations_iter = observations_iter.apply_mask(
                 pc.invert(
                     pc.is_in(
-                        observations_iter.detections.id,
+                        observations_iter.id,
                         orbit_members_out.obs_id.unique(),
                     )
                 )

--- a/thor/orbits/iod.py
+++ b/thor/orbits/iod.py
@@ -51,12 +51,12 @@ def select_observations(
         An array of selected observation IDs. If three unique observations could
         not be selected then returns an empty array.
     """
-    obs_ids = observations.detections.id.to_numpy(zero_copy_only=False)
+    obs_ids = observations.id.to_numpy(zero_copy_only=False)
     if len(obs_ids) < 3:
         return np.array([])
 
     indexes = np.arange(0, len(obs_ids))
-    times = observations.detections.time.mjd().to_numpy(zero_copy_only=False)
+    times = observations.coordinates.time.mjd().to_numpy(zero_copy_only=False)
 
     if method == "first+middle+last":
         selected_times = np.percentile(times, [0, 50, 100], interpolation="nearest")
@@ -140,7 +140,7 @@ def iod_worker(
             pc.equal(linkage_members.column(linkage_id_col), linkage_id)
         ).obs_id
         observations_linkage = observations.apply_mask(
-            pc.is_in(observations.detections.id, obs_ids)
+            pc.is_in(observations.id, obs_ids)
         )
 
         iod_orbit, iod_orbit_members = iod(
@@ -270,15 +270,15 @@ def iod(
     if len(observations) == 0:
         processable = False
 
-    obs_ids_all = observations.detections.id.to_numpy(zero_copy_only=False)
-    coords_all = observations.to_spherical_coordinates()
+    obs_ids_all = observations.id.to_numpy(zero_copy_only=False)
+    coords_all = observations.coordinates
     observers_with_states = observations.get_observers()
     observers = observers_with_states.observers
     coords_obs_all = observers_with_states.observers.coordinates.r
     times_all = coords_all.time.mjd().to_numpy(zero_copy_only=False)
 
     chi2_sol = 1e10
-    orbit_sol = None
+    orbit_sol: FittedOrbits = FittedOrbits.empty()
     obs_ids_sol = None
     arc_length = None
     outliers = np.array([])

--- a/thor/orbits/od.py
+++ b/thor/orbits/od.py
@@ -50,9 +50,7 @@ def od_worker(
         obs_ids = orbit_members.apply_mask(
             pc.equal(orbit_members.orbit_id, orbit_id)
         ).obs_id
-        orbit_observations = observations.apply_mask(
-            pc.is_in(observations.detections.id, obs_ids)
-        )
+        orbit_observations = observations.apply_mask(pc.is_in(observations.id, obs_ids))
 
         od_orbit, od_orbit_members = od(
             orbit,
@@ -108,8 +106,8 @@ def od(
         err = "method should be one of 'central' or 'finite'."
         raise ValueError(err)
 
-    obs_ids_all = observations.detections.id.to_numpy(zero_copy_only=False)
-    coords = observations.to_spherical_coordinates()
+    obs_ids_all = observations.id.to_numpy(zero_copy_only=False)
+    coords = observations.coordinates
     coords_sigma = coords.covariance.sigmas[:, 1:3]
     observers_with_states = observations.get_observers()
     observers = observers_with_states.observers
@@ -511,7 +509,7 @@ def od(
 
     else:
 
-        obs_times = observations.detections.time.mjd().to_numpy()[ids_mask]
+        obs_times = observations.coordinates.time.mjd().to_numpy()[ids_mask]
         arc_length_ = obs_times.max() - obs_times.min()
         assert arc_length == arc_length_
 

--- a/thor/orbits/tests/test_attribution.py
+++ b/thor/orbits/tests/test_attribution.py
@@ -1,23 +1,27 @@
 import pytest
-from adam_core.observations import PointSourceDetections
+from adam_core.coordinates import Origin, SphericalCoordinates
 from adam_core.time import Timestamp
 
 from ...observations.observations import Observations
+from ...observations.photometry import Photometry
 from ..attribution import Attributions
 
 
 def test_Attributions_drop_coincident_attributions():
     observations = Observations.from_kwargs(
-        detections=PointSourceDetections.from_kwargs(
-            id=["01", "02", "03", "04"],
-            exposure_id=["e01", "e01", "e02", "e02"],
+        id=["01", "02", "03", "04"],
+        exposure_id=["e01", "e01", "e02", "e02"],
+        coordinates=SphericalCoordinates.from_kwargs(
             time=Timestamp.from_mjd([59001.1, 59001.1, 59002.1, 59002.1], scale="utc"),
-            ra=[1, 2, 3, 4],
-            dec=[5, 6, 7, 8],
+            lon=[1, 2, 3, 4],
+            lat=[5, 6, 7, 8],
+            origin=Origin.from_kwargs(code=["500", "500", "500", "500"]),
+        ),
+        photometry=Photometry.from_kwargs(
+            filter=["g", "g", "g", "g"],
             mag=[10, 11, 12, 13],
         ),
         state_id=[0, 0, 1, 1],
-        observatory_code=["500", "500", "500", "500"],
     )
 
     attributions = Attributions.from_kwargs(

--- a/thor/range_and_transform.py
+++ b/thor/range_and_transform.py
@@ -68,7 +68,7 @@ def range_and_transform_worker(
 
     # Transform the detections into the co-rotating frame
     return TransformedDetections.from_kwargs(
-        id=observations_state.detections.id,
+        id=observations_state.id,
         coordinates=GnomonicCoordinates.from_cartesian(
             ranged_detections_state,
             center_cartesian=ephemeris_state.ephemeris.aberrated_coordinates,
@@ -78,6 +78,10 @@ def range_and_transform_worker(
 
 
 range_and_transform_remote = ray.remote(range_and_transform_worker)
+range_and_transform_remote = range_and_transform_remote.options(
+    num_cpus=1,
+    num_returns=1,
+)
 
 
 def range_and_transform(

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -232,12 +232,7 @@ def test_link_test_orbit(
     else:
         integration_config.max_processes = 1
 
-    (
-        test_orbit,
-        observations,
-        obs_ids_expected,
-        integration_config,
-    ) = setup_test_data(
+    (test_orbit, observations, obs_ids_expected, integration_config,) = setup_test_data(
         object_id, orbits, observations, integration_config, max_arc_length=14
     )
 
@@ -264,12 +259,7 @@ def test_benchmark_link_test_orbit(
     else:
         integration_config.max_processes = 1
 
-    (
-        test_orbit,
-        observations,
-        obs_ids_expected,
-        integration_config,
-    ) = setup_test_data(
+    (test_orbit, observations, obs_ids_expected, integration_config,) = setup_test_data(
         object_id, orbits, observations, integration_config, max_arc_length=14
     )
 

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -307,7 +307,7 @@ def test_load_initial_checkpoint_values(working_dir):
 
     assert checkpoint.stage == "range_and_transform"
     assert len(checkpoint.filtered_observations) == len(filtered_observations)
-    assert checkpoint.filtered_observations.detections.time.scale == "utc"
+    assert checkpoint.filtered_observations.coordinates.time.scale == "utc"
 
     # Create transformed_detections file to simulate second checkpoint
     TransformedDetections.empty().to_parquet(

--- a/thor/tests/test_main.py
+++ b/thor/tests/test_main.py
@@ -5,16 +5,16 @@ import pyarrow.compute as pc
 import pytest
 from adam_core.utils.helpers import make_observations, make_real_orbits
 
-from ..config import Config
-from ..main import (
+from ..checkpointing import (
     ClusterMembers,
     Clusters,
     FittedOrbitMembers,
     FittedOrbits,
     TransformedDetections,
-    link_test_orbit,
     load_initial_checkpoint_values,
 )
+from ..config import Config
+from ..main import initialize_use_ray, link_test_orbit
 from ..observations import Observations
 from ..observations.filters import TestOrbitRadiusObservationFilter
 from ..orbit import TestOrbits as THORbits
@@ -84,12 +84,7 @@ def integration_config():
 def ray_cluster():
     import ray
 
-    ray_initialized = False
-    if not ray.is_initialized():
-        ray.init(
-            num_cpus=4, include_dashboard=False, namespace="THOR Integration Tests"
-        )
-        ray_initialized = True
+    ray_initialized = initialize_use_ray(Config())
     yield
     if ray_initialized:
         ray.shutdown()
@@ -204,7 +199,6 @@ def test_range_and_transform(object_id, orbits, observations, integration_config
 
 def run_link_test_orbit(test_orbit, observations, config):
     for stage_results in link_test_orbit(test_orbit, observations, config=config):
-        print(stage_results.name)
         if stage_results.name == "recover_orbits":
             recovered_orbits, recovered_orbit_members = stage_results.result
             return recovered_orbits, recovered_orbit_members
@@ -238,7 +232,12 @@ def test_link_test_orbit(
     else:
         integration_config.max_processes = 1
 
-    (test_orbit, observations, obs_ids_expected, integration_config,) = setup_test_data(
+    (
+        test_orbit,
+        observations,
+        obs_ids_expected,
+        integration_config,
+    ) = setup_test_data(
         object_id, orbits, observations, integration_config, max_arc_length=14
     )
 
@@ -265,7 +264,12 @@ def test_benchmark_link_test_orbit(
     else:
         integration_config.max_processes = 1
 
-    (test_orbit, observations, obs_ids_expected, integration_config,) = setup_test_data(
+    (
+        test_orbit,
+        observations,
+        obs_ids_expected,
+        integration_config,
+    ) = setup_test_data(
         object_id, orbits, observations, integration_config, max_arc_length=14
     )
 
@@ -318,7 +322,6 @@ def test_load_initial_checkpoint_values(working_dir):
     assert checkpoint.stage == "cluster_and_link"
     assert checkpoint.filtered_observations is not None
     assert checkpoint.transformed_detections is not None
-    assert checkpoint.transformed_detections.coordinates.time.scale == "utc"
 
     # Create clusters file to simulate third checkpoint
     Clusters.empty().to_parquet(os.path.join(working_dir, "clusters.parquet"))
@@ -343,8 +346,6 @@ def test_load_initial_checkpoint_values(working_dir):
     assert checkpoint.filtered_observations is not None
     assert checkpoint.iod_orbits is not None
     assert checkpoint.iod_orbit_members is not None
-    assert checkpoint.iod_orbits.coordinates.time.scale == "tbd"
-    assert checkpoint.iod_orbits.coordinates.frame == "ecliptic"
 
     # Create od_orbits files to simulate fifth checkpoint
     FittedOrbits.empty().to_parquet(os.path.join(working_dir, "od_orbits.parquet"))
@@ -357,8 +358,6 @@ def test_load_initial_checkpoint_values(working_dir):
     assert checkpoint.filtered_observations is not None
     assert checkpoint.od_orbits is not None
     assert checkpoint.od_orbit_members is not None
-    assert checkpoint.od_orbits.coordinates.time.scale == "tbd"
-    assert checkpoint.od_orbits.coordinates.frame == "ecliptic"
 
     # Create recovered_orbits files to simulate completed run folder
     FittedOrbits.empty().to_parquet(
@@ -372,5 +371,3 @@ def test_load_initial_checkpoint_values(working_dir):
     assert checkpoint.stage == "complete"
     assert checkpoint.recovered_orbits is not None
     assert checkpoint.recovered_orbit_members is not None
-    assert checkpoint.recovered_orbits.coordinates.time.scale == "tbd"
-    assert checkpoint.recovered_orbits.coordinates.frame == "ecliptic"

--- a/thor/utils/quivr.py
+++ b/thor/utils/quivr.py
@@ -3,6 +3,7 @@ from typing import List, Literal, Optional
 import numpy as np
 import pyarrow as pa
 import quivr as qv
+from typing_extensions import Final
 
 __all__ = [
     "drop_duplicates",
@@ -46,12 +47,10 @@ def drop_duplicates(
         0, "index", pa.array(np.arange(len(flattened_table)))
     )
 
-    if keep == "first":
-        agg_func = keep
-    elif keep == "last":
-        agg_func = keep
-    else:
-        raise ValueError("keep must be either 'first' or 'last'")
+    if keep not in ["first", "last"]:
+        raise ValueError(f"keep must be 'first' or 'last', got {keep}.")
+
+    agg_func = keep
     indices = (
         flattened_table.group_by(subset, use_threads=False)
         .aggregate([("index", agg_func)])


### PR DESCRIPTION
This PR introduces a new table `InputObservations` that represents de-normalized combinations of detections and their exposure information (such as those available in AIMS and commonly available in other places):

```python
import quivr as qv
from adam_core.time import Timestamp

class InputObservations(qv.Table):
    id = qv.StringColumn()
    exposure_id = qv.StringColumn()
    time = Timestamp.as_column()
    ra = qv.Float64Column()
    dec = qv.Float64Column()
    ra_sigma = qv.Float64Column(nullable=True)
    dec_sigma = qv.Float64Column(nullable=True)
    ra_dec_cov = qv.Float64Column(nullable=True)
    mag = qv.Float64Column()
    mag_sigma = qv.Float64Column(nullable=True)
    filter = qv.StringColumn()
    observatory_code = qv.StringColumn()
```

The Observations table has a new constructor `Observations.from_input_observations(input_observations)` that maps the input observations into the format used by THOR, namely by `link_test_orbit`.  The THOR observation table has been modified to use SphericalCoordinates instead of PointSourceDetections.

The transition to spherical coordinates is convenient since operations are more often than not done on coordinate classes and not PointSourceDetections. 

This PR also adds a Photometry table used by THOR observations which I anticipate will one day be added to adam_core for use in things like light curve fitting. 