### PR TITLE
Modify filter_observations to accept a path to a parquet file

### DIFF
--- a/thor/main.py
+++ b/thor/main.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import time
 from dataclasses import dataclass
-from typing import Iterable, Iterator, List, Literal, Optional, Tuple
+from typing import Iterable, Iterator, List, Literal, Optional, Tuple, Union
 
 import quivr as qv
 import ray
@@ -62,7 +62,7 @@ class LinkTestOrbitStageResult:
 
 def link_test_orbit(
     test_orbit: TestOrbits,
-    observations: Observations,
+    observations: Union[str, Observations],
     working_dir: Optional[str] = None,
     filters: Optional[List[ObservationFilter]] = None,
     config: Optional[Config] = None,
@@ -128,7 +128,7 @@ def link_test_orbit(
     if (
         use_ray
         and observations is not None
-        and not isinstance(observations, ray.ObjectRef)
+        and not isinstance(observations, (ray.ObjectRef, str))
     ):
         observations = ray.put(observations)
         refs_to_free.append(observations)
@@ -153,7 +153,7 @@ def link_test_orbit(
 
     if checkpoint.stage == "filter_observations":
         if use_ray:
-            if not isinstance(observations, ray.ObjectRef):
+            if not isinstance(observations, (ray.ObjectRef, str)):
                 observations = ray.put(observations)
                 refs_to_free.append(observations)
                 logger.info("Placed observations in the object store.")

--- a/thor/main.py
+++ b/thor/main.py
@@ -81,8 +81,11 @@ def link_test_orbit(
     ----------
     test_orbit : `~thor.orbit.TestOrbit`
         Test orbit to use to gather and transform observations.
-    observations : `~thor.observations.observations.Observations`
-        Observations from which range and transform the detections.
+    observations : `~thor.observations.observations.Observations` or str
+        Observations to search for moving objects. These observations can
+        be an in-memory Observations object or a path to a parquet file containing the
+        observations. If a path is provided, the observations will be loaded in chunks for
+        filtering.
     working_dir : str, optional
         Directory with persisted config and checkpointed results.
     filters : list of `~thor.observations.filters.ObservationFilter`, optional
@@ -125,14 +128,6 @@ def link_test_orbit(
     )
 
     refs_to_free = []
-    if (
-        use_ray
-        and observations is not None
-        and not isinstance(observations, (ray.ObjectRef, str))
-    ):
-        observations = ray.put(observations)
-        refs_to_free.append(observations)
-        logger.info("Placed observations in the object store.")
 
     checkpoint = load_initial_checkpoint_values(test_orbit_directory)
     logger.info(f"Starting at stage: {checkpoint.stage}")
@@ -152,12 +147,6 @@ def link_test_orbit(
         )
 
     if checkpoint.stage == "filter_observations":
-        if use_ray:
-            if not isinstance(observations, (ray.ObjectRef, str)):
-                observations = ray.put(observations)
-                refs_to_free.append(observations)
-                logger.info("Placed observations in the object store.")
-
         filtered_observations = filter_observations(
             observations, test_orbit, config, filters
         )
@@ -186,11 +175,7 @@ def link_test_orbit(
             filtered_observations=filtered_observations,
         )
 
-    # Observations are no longer needed. If we are using ray
-    # lets explicitly free the memory.
-    if use_ray and isinstance(observations, ray.ObjectRef):
-        ray.internal.free([observations])
-        logger.info("Removed observations from the object store.")
+    # Observations are no longer needed
     del observations
 
     if checkpoint.stage == "range_and_transform":

--- a/thor/observations/filters.py
+++ b/thor/observations/filters.py
@@ -324,6 +324,11 @@ def filter_observations(
 
     use_ray = initialize_use_ray(num_cpus=config.max_processes)
     if use_ray:
+
+        if isinstance(observations, Observations):
+            observations = ray.put(observations)
+            logger.info("Placed observations in the object store.")
+
         futures = []
         for state_id_chunk in _iterate_chunks(state_ids, chunk_size):
 
@@ -343,6 +348,10 @@ def filter_observations(
             )
             if filtered_observations.fragmented():
                 filtered_observations = qv.defragment(filtered_observations)
+
+        if isinstance(observations, ray.ObjectRef):
+            ray.internal.free([observations])
+            logger.info("Removed observations from the object store.")
 
     else:
 


### PR DESCRIPTION
To support this also remove ray parallelization from TestOrbitRadiusFilter in favor of parallelizing the filter_observations function. Adds a filter_observations_worker that accepts a chunk of state IDs used to either mask observations in memory or filter observations on disk.