### PR TITLE
Add tracklet formation stage to pipeline

### DIFF
--- a/.github/workflows/docker-build-lint-test.yml
+++ b/.github/workflows/docker-build-lint-test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ github.sha }}
-      OORB_DATA: /tmp/oorb/data
   
     steps:
       - name: Checkout git repo

--- a/.github/workflows/pdm-build-integration-test.yml
+++ b/.github/workflows/pdm-build-integration-test.yml
@@ -15,9 +15,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      OORB_DATA: /tmp/oorb/data
-
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v4

--- a/src/thor/checkpointing.py
+++ b/src/thor/checkpointing.py
@@ -20,6 +20,7 @@ VALID_STAGES = Literal[
     "filter_observations",
     "generate_ephemeris",
     "range_and_transform",
+    "form_tracklets",
     "cluster_and_link",
     "fit_clusters",
     "initial_orbit_determination",
@@ -49,11 +50,21 @@ class RangeAndTransform:
 
 
 @dataclass
+class FormTracklets:
+    stage: Literal["form_tracklets"]
+    test_orbit_ephemeris: Union[TestOrbitEphemeris, ray.ObjectRef]
+    filtered_observations: Union[Observations, ray.ObjectRef]
+    transformed_detections: Union[TransformedDetections, ray.ObjectRef]
+
+
+@dataclass
 class ClusterAndLink:
     stage: Literal["cluster_and_link"]
     test_orbit_ephemeris: Union[TestOrbitEphemeris, ray.ObjectRef]
     filtered_observations: Union[Observations, ray.ObjectRef]
     transformed_detections: Union[TransformedDetections, ray.ObjectRef]
+    tracklets: Optional[object] = None
+    tracklet_members: Optional[object] = None
 
 
 @dataclass
@@ -100,6 +111,7 @@ CheckpointData = Union[
     FilterObservations,
     GenerateEphemeris,
     RangeAndTransform,
+    FormTracklets,
     ClusterAndLink,
     FitClusters,
     InitialOrbitDetermination,
@@ -113,6 +125,7 @@ stage_to_model: Dict[str, type] = {
     "filter_observations": FilterObservations,
     "generate_ephemeris": GenerateEphemeris,
     "range_and_transform": RangeAndTransform,
+    "form_tracklets": FormTracklets,
     "cluster_and_link": ClusterAndLink,
     "fit_clusters": FitClusters,
     "initial_orbit_determination": InitialOrbitDetermination,
@@ -181,9 +194,15 @@ def detect_checkpoint_stage(test_orbit_directory: pathlib.Path) -> VALID_STAGES:
         logger.info("Found unfitted clusters, starting stage fit_clusters")
         return "fit_clusters"
 
-    if (test_orbit_directory / "transformed_detections.parquet").exists():
-        logger.info("Found transformed detections, starting stage cluster_and_link")
+    if (test_orbit_directory / "tracklets.parquet").exists() and (
+        test_orbit_directory / "tracklet_members.parquet"
+    ).exists():
+        logger.info("Found tracklets, starting stage cluster_and_link")
         return "cluster_and_link"
+
+    if (test_orbit_directory / "transformed_detections.parquet").exists():
+        logger.info("Found transformed detections, starting stage form_tracklets")
+        return "form_tracklets"
 
     if (test_orbit_directory / "test_orbit_ephemeris.parquet").exists():
         logger.info("Found test orbit ephemeris, starting stage range_and_transform")
@@ -337,12 +356,40 @@ def load_initial_checkpoint_values(
 
     if stage == "cluster_and_link":
         transformed_detections_path = pathlib.Path(test_orbit_directory, "transformed_detections.parquet")
+        tracklets_path = pathlib.Path(test_orbit_directory, "tracklets.parquet")
+        tracklet_members_path = pathlib.Path(test_orbit_directory, "tracklet_members.parquet")
+
         if transformed_detections_path.exists():
             logger.info("Found transformed detections")
             transformed_detections = TransformedDetections.from_parquet(transformed_detections_path)
 
+            tracklets = None
+            tracklet_members_data = None
+            if tracklets_path.exists() and tracklet_members_path.exists():
+                from thor.clustering.tracklets import TrackletMembers as TM
+                from thor.clustering.tracklets import Tracklets as T
+
+                logger.info("Found tracklets")
+                tracklets = T.from_parquet(tracklets_path)
+                tracklet_members_data = TM.from_parquet(tracklet_members_path)
+
             return create_checkpoint_data(
                 "cluster_and_link",
+                test_orbit_ephemeris=test_orbit_ephemeris,
+                filtered_observations=filtered_observations,
+                transformed_detections=transformed_detections,
+                tracklets=tracklets,
+                tracklet_members=tracklet_members_data,
+            )
+
+    if stage == "form_tracklets":
+        transformed_detections_path = pathlib.Path(test_orbit_directory, "transformed_detections.parquet")
+        if transformed_detections_path.exists():
+            logger.info("Found transformed detections, starting tracklet formation")
+            transformed_detections = TransformedDetections.from_parquet(transformed_detections_path)
+
+            return create_checkpoint_data(
+                "form_tracklets",
                 test_orbit_ephemeris=test_orbit_ephemeris,
                 filtered_observations=filtered_observations,
                 transformed_detections=transformed_detections,

--- a/src/thor/clustering/__init__.py
+++ b/src/thor/clustering/__init__.py
@@ -16,6 +16,7 @@ from .hough import HoughLineClustering
 from .kdtree import VelocityGridKDTree
 from .metrics import filter_clusters_by_length
 from .optics import VelocityGridOPTICS
+from .tracklets import Tracklets, TrackletMembers, form_tracklets
 from .velocity_grid import (
     VelocityGridBase,
     calculate_clustering_parameters_from_covariance,
@@ -38,5 +39,8 @@ __all__ = [
     "hash_obs_ids",
     "fit_clusters",
     "filter_clusters_by_length",
+    "Tracklets",
+    "TrackletMembers",
+    "form_tracklets",
     "calculate_clustering_parameters_from_covariance",
 ]

--- a/src/thor/clustering/algorithms.py
+++ b/src/thor/clustering/algorithms.py
@@ -1,8 +1,13 @@
-from typing import Optional, Protocol, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Protocol, Tuple
 
 from ..orbit import TestOrbitEphemeris
 from ..range_and_transform import TransformedDetections
 from .data import ClusterMembers, Clusters
+
+if TYPE_CHECKING:
+    from .tracklets import TrackletMembers, Tracklets
 
 
 class ClusteringAlgorithm(Protocol):
@@ -21,6 +26,8 @@ class ClusteringAlgorithm(Protocol):
         self,
         transformed_detections: TransformedDetections,
         test_orbit_ephemeris: Optional[TestOrbitEphemeris] = None,
+        tracklets: Optional[Tracklets] = None,
+        tracklet_members: Optional[TrackletMembers] = None,
     ) -> Tuple[Clusters, ClusterMembers]:
         """
         Find clusters in transformed detections.
@@ -33,6 +40,11 @@ class ClusteringAlgorithm(Protocol):
         test_orbit_ephemeris : TestOrbitEphemeris, optional
             Test orbit ephemeris with covariances, used by some algorithms
             to derive clustering parameters automatically.
+        tracklets : Tracklets, optional
+            Pre-formed tracklets. When provided, clustering may operate on
+            tracklet centroids rather than individual observations.
+        tracklet_members : TrackletMembers, optional
+            Mapping from tracklet_id to obs_id.
 
         Returns
         -------

--- a/src/thor/clustering/dbscan.py
+++ b/src/thor/clustering/dbscan.py
@@ -67,7 +67,15 @@ def _find_clusters_dbscan(
 
 
 def _dbscan_find_worker(
-    vx, vy, transformed_detections, radius=1 / 3600, min_obs=6, min_arc_length=1.5, min_nights=3
+    vx,
+    vy,
+    transformed_detections,
+    radius=1 / 3600,
+    min_obs=6,
+    min_arc_length=1.5,
+    min_nights=3,
+    tracklets=None,
+    tracklet_members=None,
 ):
     """Ray-serializable worker that uses DBSCAN point clustering."""
     return _cluster_velocity_find_worker(
@@ -80,6 +88,8 @@ def _dbscan_find_worker(
         min_nights=min_nights,
         point_cluster_fn=_find_clusters_dbscan,
         alg_name="DBSCAN",
+        tracklets=tracklets,
+        tracklet_members=tracklet_members,
     )
 
 

--- a/src/thor/clustering/fft.py
+++ b/src/thor/clustering/fft.py
@@ -144,7 +144,15 @@ def _find_clusters_fft(
 
 
 def _fft_find_worker(
-    vx, vy, transformed_detections, radius=1 / 3600, min_obs=6, min_arc_length=1.5, min_nights=3
+    vx,
+    vy,
+    transformed_detections,
+    radius=1 / 3600,
+    min_obs=6,
+    min_arc_length=1.5,
+    min_nights=3,
+    tracklets=None,
+    tracklet_members=None,
 ):
     """Ray-serializable worker that uses FFT-based density peak clustering."""
     return _cluster_velocity_find_worker(
@@ -157,6 +165,8 @@ def _fft_find_worker(
         min_nights=min_nights,
         point_cluster_fn=_find_clusters_fft,
         alg_name="FFT",
+        tracklets=tracklets,
+        tracklet_members=tracklet_members,
     )
 
 

--- a/src/thor/clustering/hotspot2d.py
+++ b/src/thor/clustering/hotspot2d.py
@@ -255,7 +255,15 @@ def _find_clusters_hotspots_2d(
 
 
 def _hotspot2d_find_worker(
-    vx, vy, transformed_detections, radius=1 / 3600, min_obs=6, min_arc_length=1.5, min_nights=3
+    vx,
+    vy,
+    transformed_detections,
+    radius=1 / 3600,
+    min_obs=6,
+    min_arc_length=1.5,
+    min_nights=3,
+    tracklets=None,
+    tracklet_members=None,
 ):
     """Ray-serializable worker that uses Hotspot2D point clustering."""
     return _cluster_velocity_find_worker(
@@ -268,6 +276,8 @@ def _hotspot2d_find_worker(
         min_nights=min_nights,
         point_cluster_fn=_find_clusters_hotspots_2d,
         alg_name="Hotspot2D",
+        tracklets=tracklets,
+        tracklet_members=tracklet_members,
     )
 
 

--- a/src/thor/clustering/hough.py
+++ b/src/thor/clustering/hough.py
@@ -172,6 +172,8 @@ class HoughLineClustering:
         self,
         transformed_detections: TransformedDetections,
         test_orbit_ephemeris=None,
+        tracklets=None,
+        tracklet_members=None,
     ) -> Tuple[Clusters, ClusterMembers]:
         """
         Find clusters using Hough-style line finding in (x, y, t) space.

--- a/src/thor/clustering/kdtree.py
+++ b/src/thor/clustering/kdtree.py
@@ -100,7 +100,15 @@ def _find_clusters_kdtree(
 
 
 def _kdtree_find_worker(
-    vx, vy, transformed_detections, radius=1 / 3600, min_obs=6, min_arc_length=1.5, min_nights=3
+    vx,
+    vy,
+    transformed_detections,
+    radius=1 / 3600,
+    min_obs=6,
+    min_arc_length=1.5,
+    min_nights=3,
+    tracklets=None,
+    tracklet_members=None,
 ):
     """Ray-serializable worker that uses KD-tree point clustering."""
     return _cluster_velocity_find_worker(
@@ -113,6 +121,8 @@ def _kdtree_find_worker(
         min_nights=min_nights,
         point_cluster_fn=_find_clusters_kdtree,
         alg_name="KDTree",
+        tracklets=tracklets,
+        tracklet_members=tracklet_members,
     )
 
 

--- a/src/thor/clustering/optics.py
+++ b/src/thor/clustering/optics.py
@@ -68,7 +68,15 @@ def _find_clusters_optics(
 
 
 def _optics_find_worker(
-    vx, vy, transformed_detections, radius=1 / 3600, min_obs=6, min_arc_length=1.5, min_nights=3
+    vx,
+    vy,
+    transformed_detections,
+    radius=1 / 3600,
+    min_obs=6,
+    min_arc_length=1.5,
+    min_nights=3,
+    tracklets=None,
+    tracklet_members=None,
 ):
     """Ray-serializable worker that uses OPTICS point clustering."""
     return _cluster_velocity_find_worker(
@@ -81,6 +89,8 @@ def _optics_find_worker(
         min_nights=min_nights,
         point_cluster_fn=_find_clusters_optics,
         alg_name="OPTICS",
+        tracklets=tracklets,
+        tracklet_members=tracklet_members,
     )
 
 

--- a/src/thor/clustering/tracklets.py
+++ b/src/thor/clustering/tracklets.py
@@ -1,0 +1,436 @@
+"""
+Tracklet formation in the co-moving gnomonic frame.
+
+Tracklets are short-arc groupings of same-night observations that are positionally
+and kinematically consistent. They are formed by finding pairs of detections across
+different exposures (states) on the same night whose relative velocity falls within
+the test orbit's velocity uncertainty ellipse.
+
+Pairs are found efficiently using KD-trees (one per exposure), and connected
+components group transitive pairs into multi-observation tracklets. Observations
+that cannot be linked form singleton tracklets so that every observation participates
+in the downstream velocity-grid clustering.
+"""
+
+import logging
+import uuid
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+import pyarrow as pa
+import pyarrow.compute as pc
+import quivr as qv
+from adam_core.time import Timestamp
+from scipy.spatial import cKDTree
+
+from ..orbit import TestOrbitEphemeris
+from ..range_and_transform import TransformedDetections
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Tracklets",
+    "TrackletMembers",
+    "form_tracklets",
+]
+
+
+class Tracklets(qv.Table):
+    """Summary table of tracklets (one row per tracklet)."""
+
+    tracklet_id = qv.LargeStringColumn()
+    night = qv.Int64Column()
+    num_obs = qv.Int64Column()
+    theta_x = qv.Float64Column()
+    theta_y = qv.Float64Column()
+    time = Timestamp.as_column()
+    vtheta_x = qv.Float64Column(nullable=True)
+    vtheta_y = qv.Float64Column(nullable=True)
+
+
+class TrackletMembers(qv.Table):
+    """Mapping from tracklet to its constituent observations."""
+
+    tracklet_id = qv.LargeStringColumn()
+    obs_id = qv.LargeStringColumn()
+
+
+# ---------------------------------------------------------------------------
+# Union-Find for connected components
+# ---------------------------------------------------------------------------
+
+
+class _UnionFind:
+    """Simple union-find (disjoint set) data structure."""
+
+    __slots__ = ("parent", "rank")
+
+    def __init__(self, n: int):
+        self.parent = list(range(n))
+        self.rank = [0] * n
+
+    def find(self, x: int) -> int:
+        while self.parent[x] != x:
+            self.parent[x] = self.parent[self.parent[x]]
+            x = self.parent[x]
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        if self.rank[ra] < self.rank[rb]:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+        if self.rank[ra] == self.rank[rb]:
+            self.rank[ra] += 1
+
+
+# ---------------------------------------------------------------------------
+# Velocity covariance extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_velocity_bounds(
+    test_orbit_ephemeris: TestOrbitEphemeris,
+    transformed_detections: TransformedDetections,
+    mahalanobis_distance: float = 3.0,
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], float]:
+    """
+    Extract velocity covariance from ephemeris and compute bounds.
+
+    Returns
+    -------
+    vel_cov_inv : (2, 2) array
+        Inverse of the mean 2x2 velocity covariance in the gnomonic frame.
+    vel_sigmas : (2,) array
+        (sigma_vx, sigma_vy) standard deviations.
+    v_max : float
+        Maximum scalar velocity for spatial pre-filtering (mahalanobis_distance
+        times the larger sigma).
+    """
+    # Filter ephemeris to observation time range
+    obs_times_mjd = (
+        transformed_detections.coordinates.time.rescale("utc").mjd().to_numpy(zero_copy_only=False)
+    )
+    obs_time_min = obs_times_mjd.min()
+    obs_time_max = obs_times_mjd.max()
+
+    ephemeris_gnomonic = test_orbit_ephemeris.gnomonic
+    ephem_times_mjd = ephemeris_gnomonic.time.rescale("utc").mjd().to_numpy(zero_copy_only=False)
+
+    time_mask = (ephem_times_mjd >= obs_time_min) & (ephem_times_mjd <= obs_time_max)
+    if not np.any(time_mask):
+        raise ValueError(
+            f"No ephemeris points found in observation time range "
+            f"[{obs_time_min:.2f}, {obs_time_max:.2f}] MJD"
+        )
+    ephemeris_gnomonic = ephemeris_gnomonic.apply_mask(time_mask)
+
+    covariances = ephemeris_gnomonic.covariance.to_matrix()
+    mean_cov = np.nanmean(covariances, axis=0)
+    vel_cov = mean_cov[2:4, 2:4]
+
+    if np.any(np.isnan(vel_cov)) or np.any(~np.isfinite(vel_cov)):
+        raise ValueError("Velocity covariance matrix contains NaN or infinite values.")
+
+    vel_cov_inv = np.linalg.inv(vel_cov)
+    sigma_vx = np.sqrt(vel_cov[0, 0])
+    sigma_vy = np.sqrt(vel_cov[1, 1])
+    v_max = mahalanobis_distance * max(sigma_vx, sigma_vy)
+
+    return vel_cov_inv, np.array([sigma_vx, sigma_vy]), v_max
+
+
+# ---------------------------------------------------------------------------
+# Core tracklet formation
+# ---------------------------------------------------------------------------
+
+
+def form_tracklets(
+    transformed_detections: TransformedDetections,
+    test_orbit_ephemeris: TestOrbitEphemeris,
+    min_obs: int = 2,
+    max_velocity: Optional[float] = None,
+    mahalanobis_distance: float = 3.0,
+) -> Tuple[Tracklets, TrackletMembers]:
+    """
+    Form tracklets from transformed detections using KD-tree pair finding
+    and velocity-covariance filtering.
+
+    For each night, pairs of detections from different exposures are linked
+    if their relative velocity falls within the test orbit's velocity
+    uncertainty ellipse (Mahalanobis distance). Connected valid pairs are
+    grouped into tracklets. Observations that do not participate in any
+    multi-observation tracklet become singleton tracklets.
+
+    Parameters
+    ----------
+    transformed_detections : TransformedDetections
+        Observations in the test orbit's co-moving gnomonic frame.
+    test_orbit_ephemeris : TestOrbitEphemeris
+        Test orbit ephemeris with gnomonic covariances for velocity bounds.
+    min_obs : int, optional
+        Minimum number of observations for a multi-observation tracklet.
+        Tracklets with fewer members are dissolved into singletons.
+        [Default = 2]
+    max_velocity : float, optional
+        Hard upper bound on velocity magnitude in deg/day. If None, the
+        bound is derived from the ephemeris covariance. [Default = None]
+    mahalanobis_distance : float, optional
+        Mahalanobis distance threshold for velocity filtering.
+        [Default = 3.0]
+
+    Returns
+    -------
+    tracklets : Tracklets
+        Summary table with one row per tracklet (centroid position, time,
+        velocity, and observation count).
+    tracklet_members : TrackletMembers
+        Mapping from tracklet_id to obs_id.
+    """
+    if len(transformed_detections) == 0:
+        logger.info("No detections to form tracklets from.")
+        return Tracklets.empty(), TrackletMembers.empty()
+
+    # Extract velocity bounds from ephemeris covariance
+    mahal_dist_sq = mahalanobis_distance**2
+    vel_cov_inv, vel_sigmas, v_max_cov = _extract_velocity_bounds(
+        test_orbit_ephemeris, transformed_detections, mahalanobis_distance
+    )
+    if max_velocity is not None:
+        v_max = max_velocity
+    else:
+        v_max = v_max_cov
+
+    logger.info(
+        f"Tracklet velocity bounds: σ_vx={vel_sigmas[0]:.6f}, σ_vy={vel_sigmas[1]:.6f} deg/day, "
+        f"v_max={v_max:.6f} deg/day ({mahalanobis_distance:.1f}-sigma)"
+    )
+
+    # Extract arrays once
+    all_obs_ids = transformed_detections.id.to_numpy(zero_copy_only=False)
+    all_nights = transformed_detections.night.to_numpy(zero_copy_only=False)
+    all_state_ids = transformed_detections.state_id.to_numpy(zero_copy_only=False)
+    all_x = transformed_detections.coordinates.theta_x.to_numpy(zero_copy_only=False)
+    all_y = transformed_detections.coordinates.theta_y.to_numpy(zero_copy_only=False)
+    all_mjd = transformed_detections.coordinates.time.rescale("utc").mjd().to_numpy(zero_copy_only=False)
+
+    # Build a global index → obs_id mapping and work with integer indices
+    n_total = len(all_obs_ids)
+    uf = _UnionFind(n_total)
+    linked = np.zeros(n_total, dtype=bool)
+
+    unique_nights = np.unique(all_nights)
+    total_pairs = 0
+
+    for night in unique_nights:
+        night_mask = all_nights == night
+        night_indices = np.where(night_mask)[0]
+
+        if len(night_indices) == 0:
+            continue
+
+        # Group by state_id within this night
+        night_state_ids = all_state_ids[night_indices]
+        unique_states = np.unique(night_state_ids)
+
+        if len(unique_states) < 2:
+            # Only one exposure this night — no pairs possible
+            continue
+
+        # Build per-state data
+        state_data: Dict[str, Tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]] = {}
+        for sid in unique_states:
+            state_mask = night_state_ids == sid
+            idx = night_indices[state_mask]
+            x = all_x[idx]
+            y = all_y[idx]
+            mjd = all_mjd[idx]
+
+            # Filter NaNs
+            finite = np.isfinite(x) & np.isfinite(y) & np.isfinite(mjd)
+            if not np.all(finite):
+                idx = idx[finite]
+                x = x[finite]
+                y = y[finite]
+                mjd = mjd[finite]
+
+            if len(idx) > 0:
+                state_data[sid] = (idx, x, y, mjd)
+
+        state_keys = sorted(state_data.keys())
+
+        # For each pair of states, find consistent pairs
+        for i_s in range(len(state_keys)):
+            for j_s in range(i_s + 1, len(state_keys)):
+                sid_a = state_keys[i_s]
+                sid_b = state_keys[j_s]
+                idx_a, x_a, y_a, mjd_a = state_data[sid_a]
+                idx_b, x_b, y_b, mjd_b = state_data[sid_b]
+
+                # Use representative dt (mean time difference between states)
+                dt = np.mean(mjd_b) - np.mean(mjd_a)
+                if abs(dt) < 1e-10:
+                    continue
+
+                search_radius = v_max * abs(dt)
+
+                # Build KD-tree on state B
+                points_b = np.column_stack([x_b, y_b])
+                tree_b = cKDTree(points_b)
+
+                # Query for each detection in state A
+                points_a = np.column_stack([x_a, y_a])
+                candidates = tree_b.query_ball_point(points_a, search_radius)
+
+                for ia, cand_list in enumerate(candidates):
+                    if len(cand_list) == 0:
+                        continue
+
+                    # Compute per-detection dt for accurate velocity
+                    dt_ia = mjd_b[cand_list] - mjd_a[ia]
+                    # Skip any zero dt
+                    valid_dt = np.abs(dt_ia) > 1e-10
+                    if not np.any(valid_dt):
+                        continue
+
+                    cand_arr = np.array(cand_list)[valid_dt]
+                    dt_ia = dt_ia[valid_dt]
+
+                    # Compute velocity vectors
+                    dvx = (x_b[cand_arr] - x_a[ia]) / dt_ia
+                    dvy = (y_b[cand_arr] - y_a[ia]) / dt_ia
+
+                    # Mahalanobis distance filter: v^T @ Sigma_inv @ v <= threshold
+                    vel_vectors = np.column_stack([dvx, dvy])
+                    mahal_sq = np.sum(vel_vectors @ vel_cov_inv * vel_vectors, axis=1)
+                    accept = mahal_sq <= mahal_dist_sq
+
+                    if max_velocity is not None:
+                        v_mag = np.sqrt(dvx**2 + dvy**2)
+                        accept &= v_mag <= max_velocity
+
+                    # Union accepted pairs
+                    global_a = idx_a[ia]
+                    for jb in cand_arr[accept]:
+                        global_b = idx_b[jb]
+                        uf.union(global_a, global_b)
+                        linked[global_a] = True
+                        linked[global_b] = True
+                        total_pairs += 1
+
+    logger.info(f"Found {total_pairs} valid observation pairs across {len(unique_nights)} nights.")
+
+    # Build connected components
+    components: Dict[int, List[int]] = {}
+    for i in range(n_total):
+        root = uf.find(i)
+        if root not in components:
+            components[root] = []
+        components[root].append(i)
+
+    # Separate multi-obs tracklets from singletons
+    tracklet_groups: List[npt.NDArray[np.int64]] = []
+    singleton_indices: List[int] = []
+
+    for indices in components.values():
+        if len(indices) >= min_obs:
+            tracklet_groups.append(np.array(indices, dtype=np.int64))
+        else:
+            singleton_indices.extend(indices)
+
+    n_multi = len(tracklet_groups)
+    n_singleton = len(singleton_indices)
+    n_multi_obs = sum(len(g) for g in tracklet_groups)
+    logger.info(
+        f"Formed {n_multi} multi-observation tracklets ({n_multi_obs} obs) "
+        f"and {n_singleton} singletons."
+    )
+
+    # Build output tables
+    tracklet_ids: List[str] = []
+    tracklet_nights: List[int] = []
+    tracklet_num_obs: List[int] = []
+    tracklet_theta_x: List[float] = []
+    tracklet_theta_y: List[float] = []
+    tracklet_mjds: List[float] = []
+    tracklet_vx: List[Optional[float]] = []
+    tracklet_vy: List[Optional[float]] = []
+    member_tracklet_ids: List[str] = []
+    member_obs_ids: List[str] = []
+
+    def _add_tracklet(indices: npt.NDArray[np.int64]) -> None:
+        tid = uuid.uuid4().hex
+        obs_ids = all_obs_ids[indices]
+        x = all_x[indices]
+        y = all_y[indices]
+        mjd = all_mjd[indices]
+        night = all_nights[indices[0]]
+
+        # Centroid
+        cx = np.nanmean(x)
+        cy = np.nanmean(y)
+        ct = np.nanmean(mjd)
+
+        # Velocity from linear fit (or finite difference for 2 obs)
+        n = len(indices)
+        if n >= 2:
+            dt_local = mjd - ct
+            if np.ptp(dt_local) > 1e-10:
+                # Simple linear regression: v = Σ(dt * dx) / Σ(dt²)
+                dx = x - cx
+                dy = y - cy
+                dt2 = np.sum(dt_local**2)
+                vx_fit = float(np.sum(dt_local * dx) / dt2)
+                vy_fit = float(np.sum(dt_local * dy) / dt2)
+            else:
+                vx_fit = None
+                vy_fit = None
+        else:
+            vx_fit = None
+            vy_fit = None
+
+        tracklet_ids.append(tid)
+        tracklet_nights.append(int(night))
+        tracklet_num_obs.append(n)
+        tracklet_theta_x.append(float(cx))
+        tracklet_theta_y.append(float(cy))
+        tracklet_mjds.append(float(ct))
+        tracklet_vx.append(vx_fit)
+        tracklet_vy.append(vy_fit)
+
+        for oid in obs_ids:
+            member_tracklet_ids.append(tid)
+            member_obs_ids.append(str(oid))
+
+    # Multi-observation tracklets
+    for group in tracklet_groups:
+        _add_tracklet(group)
+
+    # Singleton tracklets
+    for idx in singleton_indices:
+        _add_tracklet(np.array([idx], dtype=np.int64))
+
+    # Build Timestamp from mean MJDs
+    tracklet_times = Timestamp.from_mjd(tracklet_mjds, scale="utc")
+
+    tracklets = Tracklets.from_kwargs(
+        tracklet_id=tracklet_ids,
+        night=tracklet_nights,
+        num_obs=tracklet_num_obs,
+        theta_x=tracklet_theta_x,
+        theta_y=tracklet_theta_y,
+        time=tracklet_times,
+        vtheta_x=tracklet_vx,
+        vtheta_y=tracklet_vy,
+    )
+
+    tracklet_members = TrackletMembers.from_kwargs(
+        tracklet_id=member_tracklet_ids,
+        obs_id=member_obs_ids,
+    )
+
+    logger.info(f"Total tracklets: {len(tracklets)} ({n_multi} multi-obs + {n_singleton} singletons)")
+    return tracklets, tracklet_members

--- a/src/thor/clustering/velocity_grid.py
+++ b/src/thor/clustering/velocity_grid.py
@@ -405,6 +405,7 @@ def _cluster_velocity(
         List[npt.NDArray[np.int64]],
     ],
     alg_name: str = "clustering",
+    tracklet_member_obs_ids: Optional[dict] = None,
 ) -> Tuple[Clusters, ClusterMembers]:
     """
     Cluster THOR projection at a single velocity hypothesis.
@@ -415,9 +416,9 @@ def _cluster_velocity(
     Parameters
     ----------
     obs_ids : array-like
-        Observation IDs.
+        Observation IDs (or tracklet IDs when tracklets are used).
     x, y : ndarray
-        Gnomonic coordinates in degrees.
+        Gnomonic coordinates in degrees (or tracklet centroids).
     dt : ndarray
         Time offsets from first observation in days.
     nights : ndarray
@@ -436,6 +437,10 @@ def _cluster_velocity(
         2D clustering function with signature ``(points, eps, min_samples) -> list[ndarray]``.
     alg_name : str
         Algorithm name for log messages.
+    tracklet_member_obs_ids : dict, optional
+        When clustering on tracklet centroids, a mapping from tracklet_id
+        to list of obs_ids. If provided, cluster membership is expanded
+        from tracklets back to individual observations.
 
     Returns
     -------
@@ -486,13 +491,23 @@ def _cluster_velocity(
     cluster_members_cluster_ids = []
     cluster_members_obs_ids = []
     for cluster in clusters:
-        id = uuid.uuid4().hex
-        obs_ids_i = obs_ids[cluster]
+        cid = uuid.uuid4().hex
+        ids_in_cluster = obs_ids[cluster]
+
+        if tracklet_member_obs_ids is not None:
+            # Expand tracklet IDs to observation IDs
+            expanded = []
+            for tid in ids_in_cluster:
+                expanded.extend(tracklet_member_obs_ids[tid])
+            obs_ids_i = np.array(expanded)
+        else:
+            obs_ids_i = ids_in_cluster
+
         num_obs = len(obs_ids_i)
 
-        cluster_ids.append(id)
+        cluster_ids.append(cid)
         cluster_num_obs.append(num_obs)
-        cluster_members_cluster_ids.append(np.full(num_obs, id))
+        cluster_members_cluster_ids.append(np.full(num_obs, cid))
         cluster_members_obs_ids.append(obs_ids_i)
 
     clusters_table = Clusters.from_kwargs(
@@ -521,6 +536,8 @@ def _cluster_velocity_find_worker(
     min_nights: int,
     point_cluster_fn: Callable,
     alg_name: str = "clustering",
+    tracklets: Optional[object] = None,
+    tracklet_members: Optional[object] = None,
 ) -> Tuple[Clusters, ClusterMembers]:
     """
     Worker that clusters a batch of velocity hypotheses and deduplicates.
@@ -537,6 +554,11 @@ def _cluster_velocity_find_worker(
         2D clustering function.
     alg_name : str
         Algorithm name for log messages.
+    tracklets : Tracklets, optional
+        Pre-formed tracklets. When provided, clustering operates on
+        tracklet centroids.
+    tracklet_members : TrackletMembers, optional
+        Mapping from tracklet_id to obs_id.
 
     Returns
     -------
@@ -545,11 +567,32 @@ def _cluster_velocity_find_worker(
     """
     time_start = time.perf_counter()
 
-    obs_ids = transformed_detections.id.to_numpy(zero_copy_only=False)
-    nights = transformed_detections.night.to_numpy(zero_copy_only=False)
-    x = transformed_detections.coordinates.theta_x.to_numpy(zero_copy_only=False)
-    y = transformed_detections.coordinates.theta_y.to_numpy(zero_copy_only=False)
-    mjd = transformed_detections.coordinates.time.mjd().to_numpy(zero_copy_only=False)
+    # Determine whether to cluster on tracklet centroids or raw observations
+    tracklet_member_obs_ids = None
+    if tracklets is not None and tracklet_members is not None and len(tracklets) > 0:
+        # Cluster on tracklet centroids
+        point_ids = tracklets.tracklet_id.to_numpy(zero_copy_only=False)
+        nights = tracklets.night.to_numpy(zero_copy_only=False)
+        x = tracklets.theta_x.to_numpy(zero_copy_only=False)
+        y = tracklets.theta_y.to_numpy(zero_copy_only=False)
+        mjd = tracklets.time.rescale("utc").mjd().to_numpy(zero_copy_only=False)
+
+        # Build tracklet_id -> [obs_id, ...] lookup
+        tracklet_member_obs_ids = {}
+        tm_tids = tracklet_members.tracklet_id.to_numpy(zero_copy_only=False)
+        tm_oids = tracklet_members.obs_id.to_numpy(zero_copy_only=False)
+        for tid, oid in zip(tm_tids, tm_oids):
+            if tid not in tracklet_member_obs_ids:
+                tracklet_member_obs_ids[tid] = []
+            tracklet_member_obs_ids[tid].append(oid)
+    else:
+        # Cluster on raw observations
+        point_ids = transformed_detections.id.to_numpy(zero_copy_only=False)
+        nights = transformed_detections.night.to_numpy(zero_copy_only=False)
+        x = transformed_detections.coordinates.theta_x.to_numpy(zero_copy_only=False)
+        y = transformed_detections.coordinates.theta_y.to_numpy(zero_copy_only=False)
+        mjd = transformed_detections.coordinates.time.mjd().to_numpy(zero_copy_only=False)
+
     dt = mjd - mjd.min()
 
     all_clusters = Clusters.empty()
@@ -557,7 +600,7 @@ def _cluster_velocity_find_worker(
 
     for vx_i, vy_i in zip(vx, vy):
         clusters_i, cluster_members_i = _cluster_velocity(
-            obs_ids,
+            point_ids,
             x,
             y,
             dt,
@@ -570,6 +613,7 @@ def _cluster_velocity_find_worker(
             min_nights=min_nights,
             point_cluster_fn=point_cluster_fn,
             alg_name=alg_name,
+            tracklet_member_obs_ids=tracklet_member_obs_ids,
         )
         if len(clusters_i) == 0:
             continue
@@ -713,6 +757,8 @@ class VelocityGridBase(abc.ABC):
         self,
         transformed_detections: TransformedDetections,
         test_orbit_ephemeris: Optional[TestOrbitEphemeris] = None,
+        tracklets: Optional[object] = None,
+        tracklet_members: Optional[object] = None,
     ) -> Tuple[Clusters, ClusterMembers]:
         """
         Find clusters using velocity-grid sweep + 2D point clustering.
@@ -723,6 +769,11 @@ class VelocityGridBase(abc.ABC):
             Observations in the test orbit's co-moving gnomonic frame.
         test_orbit_ephemeris : TestOrbitEphemeris, optional
             If provided, clustering parameters are calculated from covariances.
+        tracklets : Tracklets, optional
+            Pre-formed tracklets. When provided, clustering operates on
+            tracklet centroids instead of individual observations.
+        tracklet_members : TrackletMembers, optional
+            Mapping from tracklet_id to obs_id.
 
         Returns
         -------
@@ -786,8 +837,18 @@ class VelocityGridBase(abc.ABC):
             logger.info(f"Clustering completed in {time_end_cluster - time_start_cluster:.3f} seconds.")
             return Clusters.empty(), ClusterMembers.empty()
 
+        if tracklets is not None and tracklet_members is not None and len(tracklets) > 0:
+            n_tracklets = len(tracklets)
+            n_multi = int(np.sum(np.array(tracklets.num_obs.to_pylist()) > 1))
+            logger.info(
+                f"Using {n_tracklets} tracklets ({n_multi} multi-obs) "
+                f"instead of {len(transformed_detections)} raw observations."
+            )
+
         # Run velocity grid sweep
-        all_clusters, all_cluster_members = self._run_velocity_sweep(vxx, vyy, transformed_detections, radius)
+        all_clusters, all_cluster_members = self._run_velocity_sweep(
+            vxx, vyy, transformed_detections, radius, tracklets=tracklets, tracklet_members=tracklet_members
+        )
 
         num_clusters = len(all_clusters)
         if num_clusters == 0:
@@ -882,6 +943,8 @@ class VelocityGridBase(abc.ABC):
         vyy: npt.NDArray[np.float64],
         transformed_detections: TransformedDetections,
         radius: float,
+        tracklets: Optional[object] = None,
+        tracklet_members: Optional[object] = None,
     ) -> Tuple[Clusters, ClusterMembers]:
         """Execute velocity sweep across all grid points."""
         all_clusters = Clusters.empty()
@@ -919,6 +982,13 @@ class VelocityGridBase(abc.ABC):
                 transformed_ref = ray.put(transformed_detections)
                 logger.info("Placed transformed detections in the object store.")
 
+            tracklets_ref = None
+            tracklet_members_ref = None
+            if tracklets is not None and tracklet_members is not None:
+                tracklets_ref = ray.put(tracklets)
+                tracklet_members_ref = ray.put(tracklet_members)
+                logger.info("Placed tracklets in the object store.")
+
             remote_fn = self._make_ray_remote()
 
             futures = []
@@ -934,6 +1004,8 @@ class VelocityGridBase(abc.ABC):
                         min_obs=self.min_obs,
                         min_arc_length=self.min_arc_length,
                         min_nights=self.min_nights,
+                        tracklets=tracklets_ref,
+                        tracklet_members=tracklet_members_ref,
                     )
                 )
 
@@ -971,6 +1043,8 @@ class VelocityGridBase(abc.ABC):
                     min_nights=self.min_nights,
                     point_cluster_fn=point_cluster_fn,
                     alg_name=self._alg_name,
+                    tracklets=tracklets,
+                    tracklet_members=tracklet_members,
                 )
 
                 all_clusters = qv.concatenate([all_clusters, clusters_i])

--- a/src/thor/config.py
+++ b/src/thor/config.py
@@ -35,6 +35,10 @@ class Config:
     cluster_rchi2_threshold: float = 1e4
     cluster_algorithm: str = "dbscan"
     cluster_chunk_size: int = 1000
+    use_tracklets: bool = True
+    tracklet_min_obs: int = 2
+    tracklet_max_velocity: Optional[float] = None
+    tracklet_mahalanobis_distance: float = 3.0
     split_threshold: Optional[int] = None
     split_max_depth: int = 2
     split_method: Literal["healpixel", "eigenvalue"] = "eigenvalue"
@@ -43,6 +47,7 @@ class Config:
             "filter_observations",
             "generate_ephemeris",
             "range_and_transform",
+            "form_tracklets",
             "cluster_and_link",
             "fit_clusters",
             "initial_orbit_determination",

--- a/src/thor/main.py
+++ b/src/thor/main.py
@@ -20,6 +20,7 @@ from .clustering import (
     VelocityGridKDTree,
     VelocityGridOPTICS,
     fit_clusters,
+    form_tracklets,
 )
 from .config import Config, initialize_config
 from .observations.filters import (
@@ -64,6 +65,7 @@ class LinkTestOrbitStageResult:
         "filter_observations",
         "generate_ephemeris",
         "range_and_transform",
+        "form_tracklets",
         "cluster_and_link",
         "fit_clusters",
         "initial_orbit_determination",
@@ -310,16 +312,80 @@ def link_test_orbit(
                 logger.info("Placed transformed detections in the object store.")
 
         checkpoint = create_checkpoint_data(
+            "form_tracklets",
+            test_orbit_ephemeris=test_orbit_ephemeris,
+            filtered_observations=filtered_observations,
+            transformed_detections=transformed_detections,
+        )
+
+    if checkpoint.stage == "form_tracklets":
+        test_orbit_ephemeris = checkpoint.test_orbit_ephemeris
+        filtered_observations = checkpoint.filtered_observations
+        transformed_detections = checkpoint.transformed_detections
+
+        tracklets = None
+        tracklet_members = None
+        if config.use_tracklets:
+            if isinstance(transformed_detections, ray.ObjectRef):
+                td_local = ray.get(transformed_detections)
+            else:
+                td_local = transformed_detections
+            if isinstance(test_orbit_ephemeris, ray.ObjectRef):
+                toe_local = ray.get(test_orbit_ephemeris)
+            else:
+                toe_local = test_orbit_ephemeris
+
+            tracklets, tracklet_members = form_tracklets(
+                td_local,
+                toe_local,
+                min_obs=config.tracklet_min_obs,
+                max_velocity=config.tracklet_max_velocity,
+                mahalanobis_distance=config.tracklet_mahalanobis_distance,
+            )
+
+        tracklets_path = None
+        tracklet_members_path = None
+        if test_orbit_directory is not None and tracklets is not None:
+            logger.info(f"Saving tracklets to {test_orbit_directory}...")
+            tracklets_path = os.path.join(test_orbit_directory, "tracklets.parquet")
+            tracklet_members_path = os.path.join(test_orbit_directory, "tracklet_members.parquet")
+            tracklets.to_parquet(tracklets_path)
+            tracklet_members.to_parquet(tracklet_members_path)
+
+        yield LinkTestOrbitStageResult(
+            name="form_tracklets",
+            result=(
+                tracklets_path if yield_paths and tracklets_path else tracklets,
+                tracklet_members_path if yield_paths and tracklet_members_path else tracklet_members,
+            ),
+            path=(tracklets_path, tracklet_members_path),
+        )
+        if stop_after_stage == "form_tracklets":
+            return
+
+        if use_ray:
+            if not isinstance(test_orbit_ephemeris, ray.ObjectRef):
+                test_orbit_ephemeris = ray.put(test_orbit_ephemeris)
+            if not isinstance(filtered_observations, ray.ObjectRef):
+                filtered_observations = ray.put(filtered_observations)
+            if not isinstance(transformed_detections, ray.ObjectRef):
+                transformed_detections = ray.put(transformed_detections)
+
+        checkpoint = create_checkpoint_data(
             "cluster_and_link",
             test_orbit_ephemeris=test_orbit_ephemeris,
             filtered_observations=filtered_observations,
             transformed_detections=transformed_detections,
+            tracklets=tracklets,
+            tracklet_members=tracklet_members,
         )
 
     if checkpoint.stage == "cluster_and_link":
         test_orbit_ephemeris = checkpoint.test_orbit_ephemeris
         filtered_observations = checkpoint.filtered_observations
         transformed_detections = checkpoint.transformed_detections
+        tracklets = getattr(checkpoint, "tracklets", None)
+        tracklet_members = getattr(checkpoint, "tracklet_members", None)
 
         # Instantiate the clustering algorithm from config
         _algorithm_classes = {
@@ -357,6 +423,8 @@ def link_test_orbit(
         clusters, cluster_members = clustering_algorithm.find_clusters(
             transformed_detections,
             test_orbit_ephemeris=test_orbit_ephemeris,
+            tracklets=tracklets,
+            tracklet_members=tracklet_members,
         )
 
         clusters_path = None

--- a/src/thor/orbits/gauss.py
+++ b/src/thor/orbits/gauss.py
@@ -310,7 +310,7 @@ def gaussIOD(
             continue
 
         if (np.linalg.norm(orbit[:3]) > 300.0) or (np.linalg.norm(orbit[3:]) > 1.0):
-            # Orbits that crash PYOORB:
+            # Orbits with unreasonable state vectors:
             # 58366.84446725786 : 9.5544354809296721e+01  1.4093228616761269e+01 -6.6700146960148423e+00 -6.2618123281073522e+01 -9.4167879481188717e+00  4.4421501034359023e+0
             continue
 

--- a/src/thor/tests/test_main.py
+++ b/src/thor/tests/test_main.py
@@ -1,9 +1,13 @@
 import os
 import shutil
 
+import numpy as np
 import pyarrow.compute as pc
 import pytest
 from adam_assist import ASSISTPropagator
+from adam_core.coordinates import CartesianCoordinates, CoordinateCovariances
+from adam_core.orbits import Orbits
+from adam_core.orbits.variants import VariantOrbits
 from adam_core.utils.helpers import make_observations, make_real_orbits
 
 from ..checkpointing import (
@@ -315,6 +319,20 @@ def test_link_test_orbit_simple(orbits, observations, integration_config):
             (transformed_detections,) = stage_result.result
             assert len(transformed_detections) > 0, "range_and_transform produced empty result"
 
+        elif stage_result.name == "form_tracklets":
+            tracklets, tracklet_members = stage_result.result
+            if tracklets is not None:
+                from ..clustering.tracklets import TrackletMembers, Tracklets
+
+                assert isinstance(tracklets, Tracklets), "form_tracklets should return Tracklets"
+                assert isinstance(tracklet_members, TrackletMembers)
+                assert len(tracklets) > 0, "form_tracklets produced no tracklets"
+                assert len(tracklet_members) > 0, "form_tracklets produced no tracklet members"
+                # Every observation from transformed_detections should appear exactly once
+                member_obs = set(tracklet_members.obs_id.to_pylist())
+                td_obs = set(transformed_detections.id.to_pylist())
+                assert member_obs == td_obs, "Not all observations accounted for in tracklets"
+
         elif stage_result.name == "cluster_and_link":
             clusters, cluster_members = stage_result.result
             assert isinstance(clusters, Clusters), "cluster_and_link should return unfitted Clusters"
@@ -346,11 +364,134 @@ def test_link_test_orbit_simple(orbits, observations, integration_config):
             obs_ids_actual = recovered_orbit_members.obs_id
             assert pc.all(pc.equal(obs_ids_actual, obs_ids_expected))
 
-    # Verify all 8 stages executed
+    # Verify all 9 stages executed
     expected_stages = [
         "filter_observations",
         "generate_ephemeris",
         "range_and_transform",
+        "form_tracklets",
+        "cluster_and_link",
+        "fit_clusters",
+        "initial_orbit_determination",
+        "differential_correction",
+        "recover_orbits",
+    ]
+    assert stages_seen == expected_stages, f"Expected stages {expected_stages}, but saw {stages_seen}"
+
+
+@pytest.mark.integration
+def test_link_test_orbit_inflated_covariance(orbits, observations, integration_config):
+    """
+    Integration test with a perturbed test orbit sampled from an inflated covariance.
+
+    Uses the real Ivezic observations but creates an offset test orbit by:
+    1. Inflating the orbit covariance by 1e5
+    2. Sampling a variant orbit from the inflated covariance
+    3. Attaching the inflated covariance to the sampled state
+
+    This exercises tracklet formation with meaningful velocity bounds (the inflated
+    covariance produces real sigma_vx/sigma_vy values rather than near-zero).
+    """
+    object_id = "202930 Ivezic (1998 SG172)"
+    integration_config.max_processes = 1
+    covariance_scale = 1e5
+
+    (
+        _test_orbit,
+        observations,
+        obs_ids_expected,
+        integration_config,
+    ) = setup_test_data(object_id, orbits, observations, integration_config, max_arc_length=14)
+
+    # Get the original orbit and inflate its covariance
+    orbit = orbits.select("object_id", object_id)
+    cov = np.array(orbit.coordinates.covariance.values[0].as_py()).reshape(6, 6)
+    inflated_cov = cov * covariance_scale
+
+    # Build orbit with inflated covariance for sampling
+    inflated_cov_obj = CoordinateCovariances.from_matrix(inflated_cov.reshape(1, 6, 6))
+    inflated_coords = CartesianCoordinates.from_kwargs(
+        x=orbit.coordinates.x,
+        y=orbit.coordinates.y,
+        z=orbit.coordinates.z,
+        vx=orbit.coordinates.vx,
+        vy=orbit.coordinates.vy,
+        vz=orbit.coordinates.vz,
+        time=orbit.coordinates.time,
+        frame=orbit.coordinates.frame,
+        origin=orbit.coordinates.origin,
+        covariance=inflated_cov_obj,
+    )
+    inflated_orbit = Orbits.from_kwargs(
+        orbit_id=orbit.orbit_id,
+        object_id=orbit.object_id,
+        coordinates=inflated_coords,
+    )
+
+    # Sample a variant (num_samples=1 has a bug in adam_core, use 2 and take first)
+    variant = VariantOrbits.create(inflated_orbit, method="monte-carlo", num_samples=2, seed=42)[0]
+
+    # Build test orbit from the sampled state with the inflated covariance attached
+    perturbed_coords = CartesianCoordinates.from_kwargs(
+        x=variant.coordinates.x,
+        y=variant.coordinates.y,
+        z=variant.coordinates.z,
+        vx=variant.coordinates.vx,
+        vy=variant.coordinates.vy,
+        vz=variant.coordinates.vz,
+        time=orbit.coordinates.time,
+        frame=orbit.coordinates.frame,
+        origin=orbit.coordinates.origin,
+        covariance=inflated_cov_obj,
+    )
+    perturbed_orbit = Orbits.from_kwargs(
+        orbit_id=orbit.orbit_id,
+        object_id=orbit.object_id,
+        coordinates=perturbed_coords,
+    )
+    test_orbit = THORbits.from_orbits(perturbed_orbit)
+
+    # Widen the observation filter radius to account for the orbital offset
+    # (the perturbed orbit is ~4 arcsec away from the true position)
+    integration_config.filter_cell_radius = 10.0 / 3600  # 10 arcsec
+
+    stages_seen = []
+    for stage_result in link_test_orbit(test_orbit, observations, config=integration_config):
+        stages_seen.append(stage_result.name)
+
+        if stage_result.name == "form_tracklets":
+            tracklets, tracklet_members = stage_result.result
+            if tracklets is not None:
+                from ..clustering.tracklets import TrackletMembers, Tracklets
+
+                assert isinstance(tracklets, Tracklets)
+                assert isinstance(tracklet_members, TrackletMembers)
+                assert len(tracklets) > 0, "form_tracklets produced no tracklets"
+                assert len(tracklet_members) > 0, "form_tracklets produced no tracklet members"
+
+                # Check that some multi-observation tracklets formed
+                multi_obs = [n for n in tracklets.num_obs.to_pylist() if n >= 2]
+                assert len(multi_obs) > 0, "Expected multi-obs tracklets with inflated covariance"
+
+        elif stage_result.name == "recover_orbits":
+            recovered_orbits, recovered_orbit_members = stage_result.result
+            assert len(recovered_orbits) >= 1, f"Expected at least 1 recovered orbit, got {len(recovered_orbits)}"
+            # With inflated covariance the orbit is offset, so we check that we
+            # recover a substantial fraction of the expected observations
+            recovered_obs = set(recovered_orbit_members.obs_id.to_pylist())
+            expected_obs = set(obs_ids_expected.to_pylist())
+            overlap = recovered_obs & expected_obs
+            fraction = len(overlap) / len(expected_obs)
+            assert fraction >= 0.5, (
+                f"Expected to recover at least 50% of observations, got {fraction:.1%} "
+                f"({len(overlap)}/{len(expected_obs)})"
+            )
+
+    expected_stages = [
+        "filter_observations",
+        "generate_ephemeris",
+        "range_and_transform",
+        "form_tracklets",
         "cluster_and_link",
         "fit_clusters",
         "initial_orbit_determination",
@@ -395,6 +536,17 @@ def test_load_initial_checkpoint_values(working_dir):
 
     # Create transformed_detections file to simulate next checkpoint
     TransformedDetections.empty().to_parquet(os.path.join(working_dir, "transformed_detections.parquet"))
+
+    checkpoint = load_initial_checkpoint_values(working_dir)
+    assert checkpoint.stage == "form_tracklets"
+    assert checkpoint.filtered_observations is not None
+    assert checkpoint.transformed_detections is not None
+
+    # Create tracklet files to simulate form_tracklets checkpoint
+    from thor.clustering.tracklets import TrackletMembers, Tracklets
+
+    Tracklets.empty().to_parquet(os.path.join(working_dir, "tracklets.parquet"))
+    TrackletMembers.empty().to_parquet(os.path.join(working_dir, "tracklet_members.parquet"))
 
     checkpoint = load_initial_checkpoint_values(working_dir)
     assert checkpoint.stage == "cluster_and_link"

--- a/src/thor/tests/test_tracklets.py
+++ b/src/thor/tests/test_tracklets.py
@@ -1,0 +1,345 @@
+import numpy as np
+import pyarrow as pa
+from adam_core.coordinates import CartesianCoordinates, Origin
+from adam_core.observers import Observers
+from adam_core.orbits import Ephemeris
+from adam_core.time import Timestamp
+
+from thor.clustering.tracklets import (
+    TrackletMembers,
+    Tracklets,
+    _UnionFind,
+    form_tracklets,
+)
+from thor.orbit import TestOrbitEphemeris
+from thor.projections import GnomonicCoordinates
+from thor.projections.covariances import ProjectionCovariances
+from thor.range_and_transform import TransformedDetections
+
+
+def _make_transformed_detections(
+    obs_ids,
+    nights,
+    state_ids,
+    theta_x,
+    theta_y,
+    mjds,
+    test_orbit_id="test_orbit_001",
+):
+    """Helper to create TransformedDetections from arrays."""
+    n = len(obs_ids)
+    times = Timestamp.from_mjd(mjds, scale="utc")
+    coords = GnomonicCoordinates.from_kwargs(
+        theta_x=theta_x,
+        theta_y=theta_y,
+        time=times,
+        origin=Origin.from_kwargs(code=pa.repeat("SUN", n)),
+        frame="testorbit",
+    )
+    return TransformedDetections.from_kwargs(
+        id=obs_ids,
+        test_orbit_id=pa.repeat(test_orbit_id, n),
+        night=nights,
+        coordinates=coords,
+        state_id=state_ids,
+    )
+
+
+def _make_test_orbit_ephemeris(
+    mjds,
+    sigma_vx=0.01,
+    sigma_vy=0.01,
+    sigma_x=0.001,
+    sigma_y=0.001,
+):
+    """Helper to create a minimal TestOrbitEphemeris with velocity covariances."""
+    n = len(mjds)
+    times = Timestamp.from_mjd(mjds, scale="utc")
+
+    # Build 4x4 covariance matrices for gnomonic coordinates
+    cov_matrices = np.zeros((n, 4, 4))
+    cov_matrices[:, 0, 0] = sigma_x**2
+    cov_matrices[:, 1, 1] = sigma_y**2
+    cov_matrices[:, 2, 2] = sigma_vx**2
+    cov_matrices[:, 3, 3] = sigma_vy**2
+
+    gnomonic = GnomonicCoordinates.from_kwargs(
+        theta_x=np.zeros(n),
+        theta_y=np.zeros(n),
+        vtheta_x=np.zeros(n),
+        vtheta_y=np.zeros(n),
+        time=times,
+        covariance=ProjectionCovariances.from_matrix(cov_matrices),
+        origin=Origin.from_kwargs(code=pa.repeat("SUN", n)),
+        frame="testorbit",
+    )
+
+    # Build minimal Ephemeris and Observers required by TestOrbitEphemeris
+    cart = CartesianCoordinates.from_kwargs(
+        x=np.ones(n),
+        y=np.zeros(n),
+        z=np.zeros(n),
+        vx=np.zeros(n),
+        vy=np.full(n, 0.01),
+        vz=np.zeros(n),
+        time=times,
+        frame="ecliptic",
+        origin=Origin.from_kwargs(code=pa.repeat("SUN", n)),
+    )
+    ephemeris = Ephemeris.from_kwargs(
+        orbit_id=pa.repeat("test_orbit_001", n),
+        object_id=pa.repeat("obj", n),
+        coordinates=cart,
+        aberrated_coordinates=cart,
+    )
+    observers = Observers.from_kwargs(
+        code=pa.repeat("500", n),
+        coordinates=cart,
+    )
+
+    # Gnomonic rotation matrix: 6x6 identity flattened to 36 elements
+    rot_matrix = np.tile(np.eye(6).flatten(), (n, 1)).tolist()
+
+    return TestOrbitEphemeris.from_kwargs(
+        id=[f"state_{i}" for i in range(n)],
+        test_orbit_id=pa.repeat("test_orbit_001", n),
+        ephemeris=ephemeris,
+        observer=observers,
+        gnomonic=gnomonic,
+        gnomonic_rotation_matrix=rot_matrix,
+    )
+
+
+class TestUnionFind:
+    def test_basic(self):
+        uf = _UnionFind(5)
+        uf.union(0, 1)
+        uf.union(2, 3)
+        uf.union(1, 3)
+        assert uf.find(0) == uf.find(3)
+        assert uf.find(0) != uf.find(4)
+
+    def test_singleton(self):
+        uf = _UnionFind(3)
+        assert uf.find(0) != uf.find(1)
+        assert uf.find(1) != uf.find(2)
+
+
+class TestFormTracklets:
+
+    def test_empty_detections(self):
+        td = TransformedDetections.empty()
+        toe = _make_test_orbit_ephemeris([60000.0, 60001.0])
+        tracklets, members = form_tracklets(td, toe)
+        assert len(tracklets) == 0
+        assert len(members) == 0
+
+    def test_single_state_per_night(self):
+        """All observations on one night with one exposure → all singletons."""
+        td = _make_transformed_detections(
+            obs_ids=["a", "b", "c"],
+            nights=[1, 1, 1],
+            state_ids=["s1", "s1", "s1"],
+            theta_x=[0.0, 0.01, 0.02],
+            theta_y=[0.0, 0.01, 0.02],
+            mjds=[60000.0, 60000.0, 60000.0],
+        )
+        toe = _make_test_orbit_ephemeris([60000.0])
+        tracklets, members = form_tracklets(td, toe)
+
+        # All should be singletons
+        assert len(tracklets) == 3
+        assert len(members) == 3
+        assert all(n == 1 for n in tracklets.num_obs.to_pylist())
+
+    def test_basic_pair_formation(self):
+        """Two exposures on the same night, one object with consistent velocity."""
+        # Object at (0, 0) at t=60000.0 and (0.001, 0.001) at t=60000.05
+        # Velocity = (0.02, 0.02) deg/day — well within sigma_v=0.1
+        td = _make_transformed_detections(
+            obs_ids=["obj_t1", "noise_t1", "obj_t2", "noise_t2"],
+            nights=[1, 1, 1, 1],
+            state_ids=["s1", "s1", "s2", "s2"],
+            theta_x=[0.0, 0.5, 0.001, -0.5],
+            theta_y=[0.0, 0.5, 0.001, -0.5],
+            mjds=[60000.0, 60000.0, 60000.05, 60000.05],
+        )
+        toe = _make_test_orbit_ephemeris([60000.0, 60000.05], sigma_vx=0.1, sigma_vy=0.1)
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=3.0)
+
+        # The "obj" pair should form a tracklet; "noise" pair too far away
+        tracklet_list = tracklets.num_obs.to_pylist()
+        assert 2 in tracklet_list, f"Expected a 2-obs tracklet, got {tracklet_list}"
+
+        # Verify the 2-obs tracklet contains the right observations
+        multi_tracklet_ids = [
+            tid for tid, n in zip(tracklets.tracklet_id.to_pylist(), tracklet_list) if n == 2
+        ]
+        for tid in multi_tracklet_ids:
+            member_mask = members.select("tracklet_id", tid)
+            obs_ids = set(member_mask.obs_id.to_pylist())
+            assert obs_ids == {"obj_t1", "obj_t2"}
+
+    def test_velocity_filter_rejects_fast_pairs(self):
+        """Pairs whose velocity exceeds the Mahalanobis threshold are rejected."""
+        # Large displacement in short time → high velocity
+        td = _make_transformed_detections(
+            obs_ids=["a1", "a2"],
+            nights=[1, 1],
+            state_ids=["s1", "s2"],
+            theta_x=[0.0, 1.0],  # 1 degree in 0.05 days = 20 deg/day
+            theta_y=[0.0, 0.0],
+            mjds=[60000.0, 60000.05],
+        )
+        toe = _make_test_orbit_ephemeris([60000.0, 60000.05], sigma_vx=0.01, sigma_vy=0.01)
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=3.0)
+
+        # Both should be singletons because velocity (20 deg/day) >> 3 * 0.01 = 0.03 deg/day
+        assert len(tracklets) == 2
+        assert all(n == 1 for n in tracklets.num_obs.to_pylist())
+
+    def test_connected_components_three_states(self):
+        """Object observed in 3 states on same night → single 3-obs tracklet."""
+        # Consistent velocity across all three states
+        v = 0.01  # deg/day
+        dt1 = 0.04  # 58 min
+        dt2 = 0.08  # 115 min
+        td = _make_transformed_detections(
+            obs_ids=["obj_t1", "obj_t2", "obj_t3"],
+            nights=[1, 1, 1],
+            state_ids=["s1", "s2", "s3"],
+            theta_x=[0.0, v * dt1, v * dt2],
+            theta_y=[0.0, v * dt1, v * dt2],
+            mjds=[60000.0, 60000.0 + dt1, 60000.0 + dt2],
+        )
+        toe = _make_test_orbit_ephemeris(
+            [60000.0, 60000.0 + dt1, 60000.0 + dt2], sigma_vx=0.1, sigma_vy=0.1
+        )
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=3.0)
+
+        # Should form one 3-observation tracklet
+        assert 3 in tracklets.num_obs.to_pylist()
+
+    def test_multi_night_independence(self):
+        """Tracklets form independently per night — no cross-night linking."""
+        td = _make_transformed_detections(
+            obs_ids=["n1_a", "n1_b", "n2_a", "n2_b"],
+            nights=[1, 1, 2, 2],
+            state_ids=["s1", "s2", "s3", "s4"],
+            theta_x=[0.0, 0.0005, 0.0, 0.0005],
+            theta_y=[0.0, 0.0005, 0.0, 0.0005],
+            mjds=[60000.0, 60000.05, 60001.0, 60001.05],
+        )
+        toe = _make_test_orbit_ephemeris(
+            [60000.0, 60000.05, 60001.0, 60001.05], sigma_vx=0.1, sigma_vy=0.1
+        )
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=3.0)
+
+        # Should form two separate 2-obs tracklets (one per night)
+        multi = [n for n in tracklets.num_obs.to_pylist() if n == 2]
+        assert len(multi) == 2
+
+        # Each tracklet should have observations from only one night
+        for tid in tracklets.tracklet_id.to_pylist():
+            member_rows = members.select("tracklet_id", tid)
+            obs_ids = member_rows.obs_id.to_pylist()
+            # Find the night of each member observation
+            member_nights = set()
+            for oid in obs_ids:
+                idx = td.id.to_pylist().index(oid)
+                member_nights.add(td.night.to_pylist()[idx])
+            assert len(member_nights) == 1, f"Tracklet {tid} spans multiple nights: {member_nights}"
+
+    def test_tracklet_centroid_computation(self):
+        """Verify centroid position, time, and velocity are correctly computed."""
+        x1, y1, t1 = 0.0, 0.0, 60000.0
+        x2, y2, t2 = 0.002, 0.004, 60000.05
+        td = _make_transformed_detections(
+            obs_ids=["a", "b"],
+            nights=[1, 1],
+            state_ids=["s1", "s2"],
+            theta_x=[x1, x2],
+            theta_y=[y1, y2],
+            mjds=[t1, t2],
+        )
+        toe = _make_test_orbit_ephemeris([t1, t2], sigma_vx=1.0, sigma_vy=1.0)
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=10.0)
+
+        multi = [i for i, n in enumerate(tracklets.num_obs.to_pylist()) if n == 2]
+        assert len(multi) == 1
+        idx = multi[0]
+
+        # Check centroid
+        cx = tracklets.theta_x.to_pylist()[idx]
+        cy = tracklets.theta_y.to_pylist()[idx]
+        np.testing.assert_allclose(cx, (x1 + x2) / 2, atol=1e-10)
+        np.testing.assert_allclose(cy, (y1 + y2) / 2, atol=1e-10)
+
+        # Check velocity
+        expected_vx = (x2 - x1) / (t2 - t1)
+        expected_vy = (y2 - y1) / (t2 - t1)
+        vx = tracklets.vtheta_x.to_pylist()[idx]
+        vy = tracklets.vtheta_y.to_pylist()[idx]
+        np.testing.assert_allclose(vx, expected_vx, rtol=1e-6)
+        np.testing.assert_allclose(vy, expected_vy, rtol=1e-6)
+
+    def test_singleton_tracklets_have_null_velocity(self):
+        """Singleton tracklets should have null velocity."""
+        td = _make_transformed_detections(
+            obs_ids=["a"],
+            nights=[1],
+            state_ids=["s1"],
+            theta_x=[0.0],
+            theta_y=[0.0],
+            mjds=[60000.0],
+        )
+        toe = _make_test_orbit_ephemeris([60000.0])
+        tracklets, members = form_tracklets(td, toe)
+
+        assert len(tracklets) == 1
+        assert tracklets.vtheta_x.to_pylist()[0] is None
+        assert tracklets.vtheta_y.to_pylist()[0] is None
+
+    def test_every_observation_accounted_for(self):
+        """Every input observation should appear in exactly one tracklet."""
+        np.random.seed(42)
+        n_obs = 50
+        td = _make_transformed_detections(
+            obs_ids=[f"obs_{i}" for i in range(n_obs)],
+            nights=[1] * 25 + [2] * 25,
+            state_ids=["s1"] * 12 + ["s2"] * 13 + ["s3"] * 12 + ["s4"] * 13,
+            theta_x=np.random.uniform(-0.01, 0.01, n_obs),
+            theta_y=np.random.uniform(-0.01, 0.01, n_obs),
+            mjds=[60000.0] * 12 + [60000.05] * 13 + [60001.0] * 12 + [60001.05] * 13,
+        )
+        toe = _make_test_orbit_ephemeris(
+            [60000.0, 60000.05, 60001.0, 60001.05], sigma_vx=0.5, sigma_vy=0.5
+        )
+        tracklets, members = form_tracklets(td, toe, min_obs=2, mahalanobis_distance=5.0)
+
+        # Every obs_id should appear exactly once in members
+        member_obs_ids = members.obs_id.to_pylist()
+        input_obs_ids = td.id.to_pylist()
+        assert sorted(member_obs_ids) == sorted(input_obs_ids)
+
+    def test_max_velocity_override(self):
+        """max_velocity parameter should override the covariance-derived bound."""
+        # Pair with velocity = 0.02 deg/day
+        td = _make_transformed_detections(
+            obs_ids=["a", "b"],
+            nights=[1, 1],
+            state_ids=["s1", "s2"],
+            theta_x=[0.0, 0.001],
+            theta_y=[0.0, 0.0],
+            mjds=[60000.0, 60000.05],
+        )
+        # Very wide covariance would normally allow this pair
+        toe = _make_test_orbit_ephemeris([60000.0, 60000.05], sigma_vx=1.0, sigma_vy=1.0)
+
+        # With tight max_velocity, the pair should be rejected
+        tracklets, _ = form_tracklets(td, toe, min_obs=2, max_velocity=0.01)
+        assert all(n == 1 for n in tracklets.num_obs.to_pylist())
+
+        # Without max_velocity, the pair should form
+        tracklets2, _ = form_tracklets(td, toe, min_obs=2, max_velocity=None)
+        assert 2 in tracklets2.num_obs.to_pylist()


### PR DESCRIPTION
## Summary
- Adds a new `form_tracklets` pipeline stage between `range_and_transform` and `cluster_and_link` that groups same-night observations into short-arc tracklets using KD-tree spatial search and velocity-covariance Mahalanobis filtering
- When tracklets are enabled, velocity grid clustering operates on tracklet centroids instead of raw observations, then expands back to individual obs_ids
- Removes stale `OORB_DATA` references from CI workflows

## Details

**Tracklet formation** (`src/thor/clustering/tracklets.py`):
- Groups detections by night, builds KD-trees per exposure pair within `v_max * dt` radius
- Filters pairs using Mahalanobis distance against the test orbit's velocity covariance ellipse
- Union-find connected components merge transitive pairs (A↔B, B↔C → {A,B,C})
- Unlinked observations become singleton tracklets (every observation is accounted for)

**Config** (`src/thor/config.py`):
- `use_tracklets` (default: `True`), `tracklet_min_obs`, `tracklet_max_velocity`, `tracklet_mahalanobis_distance`

**Clustering integration** (`src/thor/clustering/velocity_grid.py`):
- All clustering algorithms accept optional `tracklets`/`tracklet_members` params
- Velocity grid swaps raw observations for tracklet centroids, builds tracklet_id → obs_ids lookup for expansion after clustering

**Tests**:
- 12 unit tests for tracklet formation (union-find, pair formation, velocity filtering, connected components, multi-night independence, centroid computation, etc.)
- Updated `test_link_test_orbit_simple` integration test with `form_tracklets` stage validation
- New `test_link_test_orbit_inflated_covariance` integration test: samples a variant orbit from 1e5-inflated covariance to exercise tracklet formation with meaningful velocity bounds

## Test plan
- [x] 12 tracklet unit tests pass (`test_tracklets.py`)
- [x] Checkpoint test passes (`test_load_initial_checkpoint_values`)
- [x] Integration test with exact orbit passes (`test_link_test_orbit_simple`)
- [x] Integration test with inflated covariance passes (`test_link_test_orbit_inflated_covariance`)
- [x] All 29 non-integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)